### PR TITLE
(#3) Foundation Models 자연어 파싱을 구현합니다.

### DIFF
--- a/.agents/memorys/entries/2026-03-03-core-safe-index-regex-capture.md
+++ b/.agents/memorys/entries/2026-03-03-core-safe-index-regex-capture.md
@@ -1,0 +1,68 @@
+## 제목(Title)
+- 정규식 캡처 배열 인덱스를 직접 접근해 테스트 크래시가 발생한 사례
+
+## 날짜(Date)
+- 2026-03-03
+
+## 유형(Type)
+- rejection
+
+## 키워드(Keywords)
+- workflow:test
+- workflow:review
+- action:safe-index
+- action:core-extension
+- failure:index-out-of-range
+- target:file:SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift
+- risk:high
+- verify:ai-test
+
+## 컨텍스트(Context)
+- `AITests` 실행 중 `FoundationModelsParser.resolveTime(from:)`에서 정규식 매칭 결과 배열을 고정 인덱스로 접근하여 `SIGTRAP` 크래시가 발생했습니다.
+
+## 문제 행동(Bad Action)
+- 정규식 캡처 그룹 배열에 대해 `match[1]`, `match[2]`처럼 직접 인덱싱했습니다.
+- 프로젝트에 이미 존재하는 Core 안전 인덱스 확장(`Collection[safe:]`)을 활용하지 않았습니다.
+
+## 사용자 피드백(User Feedback)
+- 사용자 요청: `컬렉션에 인덱스로 접근 시 안전하게 처리하는 익스텐션이 Core모듈에 있어. 인덱스 접근 시 이를 활용하고, 메모리에 기록해`
+
+## 원인(Root Cause)
+- 캡처 그룹의 optional 매칭 누락 가능성을 고려하지 않고 직접 접근 패턴을 사용했습니다.
+- Core 공통 확장 재사용 체크를 사전 점검에 넣지 않았습니다.
+
+## 예방 규칙(Prevention Rule)
+- 정규식/파싱 결과 배열 인덱스 접근은 항상 `Collection[safe:]`를 우선 사용합니다.
+- `Core`에 이미 존재하는 안전 유틸리티가 있으면 로컬 구현보다 공통 확장을 재사용합니다.
+- 테스트에서 크래시 발생 시 `.xcresult`의 crash attachment까지 확인해 정확한 실패 라인(파일/라인)을 원인으로 기록합니다.
+
+## 사전 점검(Pre-Command Check)
+- 배열/컬렉션 인덱스 접근 코드에 `safe` 접근이 적용되어 있는가?
+- 동일 기능의 Core 확장이 이미 존재하는지 먼저 확인했는가?
+- 파싱 로직 변경 후 대상 모듈 테스트(`AI` 스킴)가 실제 시뮬레이터에서 통과했는가?
+
+## 금지 동작(Do Not Do)
+- 정규식 캡처 배열에 직접 인덱싱(`match[n]`)을 고정 사용하지 않습니다.
+- 안전 확장을 무시하고 파일 내부에서 임시 우회 구현만 추가하지 않습니다.
+
+## 안전 대안(Safe Alternative)
+- 예: `let minute = Int(match[safe: 3] ?? "") ?? 0`
+- 예: `guard let year = Int(match[safe: 1] ?? "") else { return nil }`
+
+## 검증 단계(Verification Step)
+- `rg -n "match\\[[0-9]+\\]" SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift`
+- `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme AI -destination 'platform=iOS Simulator,id=D76E7868-D294-42A9-BA46-DD23BF6C8B9C' test`
+- 필요 시 `xcresulttool export attachments --only-failures`로 crash log 확인
+
+## 적용 범위(Scope)
+- AI/Feature/Domain 포함 파싱/정규식 처리 로직 전반
+
+## 심각도(Severity)
+- high
+
+## 예시(Examples)
+- 나쁜 예(Bad): `let minute = Int(match[3] ?? "") ?? 0`
+- 좋은 예(Good): `let minute = Int(match[safe: 3] ?? "") ?? 0`
+
+## 관련 메모리(Related Memories)
+- `entries/2026-03-03-test-annotation-korean-and-compile-safety.md`

--- a/.agents/memorys/index/MEMORY_INDEX.md
+++ b/.agents/memorys/index/MEMORY_INDEX.md
@@ -6,6 +6,7 @@
 
 | 날짜(Date) | 파일(File) | 제목(Title) | 핵심 키워드(Keywords) |
 |---|---|---|---|
+| 2026-03-03 | `entries/2026-03-03-core-safe-index-regex-capture.md` | 정규식 캡처 배열 인덱스를 직접 접근해 테스트 크래시가 발생한 사례 | workflow:test, action:safe-index, failure:index-out-of-range, verify:ai-test |
 | 2026-03-03 | `entries/2026-03-03-skill-sync-claude-agents.md` | 스킬 추가 시 `.claude`와 `.agents` 동시 반영을 누락한 사례 | workflow:skill, failure:location-miss, verify:dual-path-check |
 | 2026-03-03 | `entries/2026-03-03-branch-context-mismatch.md` | 브랜치 컨텍스트 혼선으로 범위 외 변경이 섞인 사례 | workflow:branch, failure:scope-creep, verify:diff-check |
 | 2026-03-03 | `entries/2026-03-03-mock-location-testsupport.md` | MockRepository를 테스트 파일 내부에 두어 TestSupport 규칙을 놓친 사례 | workflow:review, failure:convention-miss, target:dir:SeukCalendar/Domain/CalendarDomainTestSupport |

--- a/.agents/rules/Architecture.md
+++ b/.agents/rules/Architecture.md
@@ -85,10 +85,13 @@ SeukCalendar는 **Clean Architecture 기반의 3계층 구조**를 따릅니다.
 ### AI Layer
 
 **역할**:
-- AI 관련 기능 제공
+- 자연어 입력을 구조화된 일정 데이터(`ParsedEvent`)로 파싱
+- Domain의 `ScheduleNaturalLanguageParser` 인터페이스 구현 제공
 
 **주요 구성**:
-- 작성 필요
+- `FoundationModelsParser` (AI): Foundation Models 기반 파서
+- `ParsedEventGenerable` (AI): `@Generable` 구조체
+- `ParseEventUseCase` (Domain): 파싱 실행 + `ParsedEvent -> Schedule` 변환
 
 ---
 
@@ -250,6 +253,26 @@ View (자동 리렌더링)
 6. **Repository → ViewModel**: Domain Model 반환
 7. **ViewModel → View**: 상태 변경, 자동 리렌더링
 
+### AI 자연어 파싱 흐름
+
+```
+User Input (자연어)
+    ↓
+CalendarViewModel.send(.parseNaturalLanguage)
+    ↓
+ParseEventUseCase (Domain)
+    ↓
+ScheduleNaturalLanguageParser (Domain Interface)
+    ↑ implements
+FoundationModelsParser (AI)
+    ↓
+ParsedEvent
+    ↓ (수정 가능)
+ParseEventUseCase.toSchedule()
+    ↓
+CreateScheduleUseCase → ScheduleRepository (EventKit)
+```
+
 ---
 
 ## 네트워킹
@@ -345,6 +368,12 @@ Pool iOS 프로젝트에서 사용하는 주요 기술 및 라이브러리입니
 | **SwiftLint** | 코드 스타일 검사 |
 | **Fastlane** | 빌드 및 배포 자동화 |
 
+### AI / ML
+
+| 기술 | 용도 |
+|------|------|
+| **Foundation Models** (iOS 26+) | 자연어 일정 파싱 |
+
 ### 기술 스택 요약
 
 | 카테고리 | 주요 기술 |
@@ -352,6 +381,7 @@ Pool iOS 프로젝트에서 사용하는 주요 기술 및 라이브러리입니
 | **UI** | SwiftUI, @Observable |
 | **아키텍처** | Clean Architecture, MVVM |
 | **DI** | Swinject |
+| **AI** | Foundation Models |
 | **네트워킹** | 작성 필요 |
 | **보안** | Keychain Services |
 | **모듈 관리** | Xcode Projects (xcodeproj) |

--- a/SeukCalendar/AI/AI.xcodeproj/xcshareddata/xcschemes/AI.xcscheme
+++ b/SeukCalendar/AI/AI.xcodeproj/xcshareddata/xcschemes/AI.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7BD09B642F5148A00035BF41"
+               BuildableName = "AI.framework"
+               BlueprintName = "AI"
+               ReferencedContainer = "container:AI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7BD09B6D2F5148A00035BF41"
+               BuildableName = "AITests.xctest"
+               BlueprintName = "AITests"
+               ReferencedContainer = "container:AI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7BD09B642F5148A00035BF41"
+            BuildableName = "AI.framework"
+            BlueprintName = "AI"
+            ReferencedContainer = "container:AI.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift
+++ b/SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift
@@ -186,9 +186,9 @@ private extension FoundationModelsParser {
 
   func parseExplicitDate(from text: String) -> Date? {
     guard let match = text.firstRegexMatch(pattern: "(\\d{4})[./-](\\d{1,2})[./-](\\d{1,2})"),
-          let year = Int(match[1]),
-          let month = Int(match[2]),
-          let day = Int(match[3])
+          let year = Int(match[safe: 1] ?? ""),
+          let month = Int(match[safe: 2] ?? ""),
+          let day = Int(match[safe: 3] ?? "")
     else {
       return nil
     }
@@ -214,10 +214,10 @@ private extension FoundationModelsParser {
     ]
 
     if let match = text.firstRegexMatch(pattern: "(일|월|화|수|목|금|토)요일") {
-      return mapping[match[1]]
+      return mapping[match[safe: 1] ?? ""]
     }
     if let match = text.firstRegexMatch(pattern: "(일|월|화|수|목|금|토)요") {
-      return mapping[match[1]]
+      return mapping[match[safe: 1] ?? ""]
     }
 
     return nil
@@ -225,9 +225,9 @@ private extension FoundationModelsParser {
 
   func resolveTime(from text: String) -> String? {
     if let match = text.firstRegexMatch(pattern: "(오전|오후|아침|점심|저녁|밤)?\\s*(\\d{1,2})\\s*시(?:\\s*(\\d{1,2})\\s*분?)?"),
-       let parsedHour = Int(match[2]) {
-      let meridiem = match[1]
-      let minute = Int(match[3] ?? "") ?? 0
+       let parsedHour = Int(match[safe: 2] ?? "") {
+      let meridiem = match[safe: 1] ?? ""
+      let minute = Int(match[safe: 3] ?? "") ?? 0
       guard (0 ..< 60).contains(minute) else {
         return nil
       }
@@ -248,8 +248,8 @@ private extension FoundationModelsParser {
     }
 
     if let match = text.firstRegexMatch(pattern: "\\b(\\d{1,2}):(\\d{2})\\b"),
-       let hour = Int(match[1]),
-       let minute = Int(match[2]),
+       let hour = Int(match[safe: 1] ?? ""),
+       let minute = Int(match[safe: 2] ?? ""),
        (0 ..< 24).contains(hour),
        (0 ..< 60).contains(minute) {
       return String(format: "%02d:%02d", hour, minute)
@@ -262,19 +262,21 @@ private extension FoundationModelsParser {
     let hourMatch = text.firstRegexMatch(pattern: "(\\d+)\\s*시간")
     let minuteMatch = text.firstRegexMatch(pattern: "(\\d+)\\s*분")
 
-    let hours = hourMatch.flatMap { Int($0[1]) } ?? 0
-    let minutes = minuteMatch.flatMap { Int($0[1]) } ?? 0
+    let hours = hourMatch.flatMap { Int($0[safe: 1] ?? "") } ?? 0
+    let minutes = minuteMatch.flatMap { Int($0[safe: 1] ?? "") } ?? 0
     let total = (hours * 60) + minutes
 
     return total > 0 ? total : nil
   }
 
   func resolveLocation(from text: String) -> String? {
-    guard let match = text.firstRegexMatch(pattern: "([가-힣A-Za-z0-9\\s]{1,20})에서") else {
+    guard let match = text.firstRegexMatch(pattern: "([가-힣A-Za-z0-9]+)에서"),
+          let locationGroup = match[safe: 1]
+    else {
       return nil
     }
 
-    let location = match[1].trimmingCharacters(in: .whitespacesAndNewlines)
+    let location = locationGroup.trimmingCharacters(in: .whitespacesAndNewlines)
     return location.isEmpty ? nil : location
   }
 
@@ -319,10 +321,13 @@ private extension String {
       return nil
     }
 
-    return (0 ..< match.numberOfRanges).compactMap { index in
+    // Preserve capture indices even when optional groups are not matched.
+    return (0 ..< match.numberOfRanges).map { index in
       let nsRange = match.range(at: index)
-      guard let range = Range(nsRange, in: self) else {
-        return nil
+      guard nsRange.location != NSNotFound,
+            let range = Range(nsRange, in: self)
+      else {
+        return ""
       }
       return String(self[range])
     }

--- a/SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift
+++ b/SeukCalendar/AI/AI/FoundationModels/FoundationModelsParser.swift
@@ -1,0 +1,330 @@
+import CalendarDomain
+import Core
+import Foundation
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif
+
+public enum FoundationModelsParserError: SCError, Equatable {
+  case unsupported
+  case parsingFailed
+
+  public var errorDescription: String {
+    switch self {
+    case .unsupported:
+      "Foundation Models를 사용할 수 없는 환경입니다."
+    case .parsingFailed:
+      "Foundation Models와 휴리스틱 파싱 모두 실패했습니다."
+    }
+  }
+
+  public var userMessage: String {
+    switch self {
+    case .unsupported:
+      "현재 기기에서는 AI 파싱을 사용할 수 없습니다."
+    case .parsingFailed:
+      "일정을 해석하지 못했습니다. 날짜/시간/장소를 조금 더 명확히 입력해주세요."
+    }
+  }
+}
+
+public final class FoundationModelsParser: ScheduleNaturalLanguageParser {
+  private let calendar: Calendar
+  private let locale: Locale
+  private let preferFoundationModels: Bool
+
+  public init(
+    calendar: Calendar = .current,
+    locale: Locale = .current,
+    preferFoundationModels: Bool = true
+  ) {
+    self.calendar = calendar
+    self.locale = locale
+    self.preferFoundationModels = preferFoundationModels
+  }
+
+  public func parse(text: String, referenceDate: Date) async throws -> ParsedEvent {
+    let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedText.isEmpty else {
+      throw ScheduleNaturalLanguageParserError.emptyInput
+    }
+
+    #if canImport(FoundationModels)
+      if preferFoundationModels,
+         #available(iOS 26.0, macOS 26.0, *),
+         let foundationModelsResult = try await parseWithFoundationModels(
+           text: trimmedText,
+           referenceDate: referenceDate
+         ) {
+        return foundationModelsResult
+      }
+    #endif
+
+    if let heuristicResult = parseWithHeuristic(text: trimmedText, referenceDate: referenceDate) {
+      return heuristicResult
+    }
+
+    throw FoundationModelsParserError.parsingFailed
+  }
+}
+
+private extension FoundationModelsParser {
+  #if canImport(FoundationModels)
+    @available(iOS 26.0, macOS 26.0, *)
+    func parseWithFoundationModels(
+      text: String,
+      referenceDate: Date
+    ) async throws -> ParsedEvent? {
+      let session = LanguageModelSession(
+        instructions:
+        """
+        당신은 한국어 일정 입력을 구조화된 데이터로 변환하는 파서입니다.
+        다음 규칙을 반드시 지키세요.
+        - dateString은 반드시 절대 날짜(yyyy-MM-dd) 형식으로 출력합니다.
+        - 시간이 없으면 isAllDay=true, startTime=null 입니다.
+        - startTime은 24시간 형식(HH:mm)입니다.
+        - durationMinutes가 불분명하면 null로 둡니다.
+        - title은 간결한 일정 제목으로 정리합니다.
+        """
+      )
+
+      let dateFormatter = DateFormatter()
+      dateFormatter.calendar = calendar
+      dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+      dateFormatter.timeZone = calendar.timeZone
+      dateFormatter.dateFormat = "yyyy-MM-dd"
+      let referenceDateString = dateFormatter.string(from: referenceDate)
+
+      let prompt =
+        """
+        기준 날짜: \(referenceDateString)
+        사용자 입력: \(text)
+        """
+
+      do {
+        let response = try await session.respond(to: prompt, generating: ParsedEventGenerable.self)
+        let content = response.content
+
+        return ParsedEvent(
+          title: content.title.trimmingCharacters(in: .whitespacesAndNewlines),
+          dateString: content.dateString.trimmingCharacters(in: .whitespacesAndNewlines),
+          startTime: content.startTime?.trimmingCharacters(in: .whitespacesAndNewlines),
+          durationMinutes: content.durationMinutes,
+          location: content.location?.trimmingCharacters(in: .whitespacesAndNewlines),
+          notes: content.notes?.trimmingCharacters(in: .whitespacesAndNewlines),
+          isAllDay: content.isAllDay
+        )
+      } catch {
+        return nil
+      }
+    }
+  #endif
+
+  func parseWithHeuristic(text: String, referenceDate: Date) -> ParsedEvent? {
+    guard let resolvedDate = resolveDate(from: text, referenceDate: referenceDate) else {
+      return nil
+    }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.calendar = calendar
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = calendar.timeZone
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    let dateString = dateFormatter.string(from: resolvedDate)
+
+    let startTime = resolveTime(from: text)
+    let isAllDay = startTime == nil
+    let durationMinutes = resolveDurationMinutes(from: text) ?? (isAllDay ? 1440 : 60)
+    let location = resolveLocation(from: text)
+    let title = resolveTitle(from: text, location: location)
+
+    return ParsedEvent(
+      title: title,
+      dateString: dateString,
+      startTime: startTime,
+      durationMinutes: durationMinutes,
+      location: location,
+      notes: nil,
+      isAllDay: isAllDay
+    )
+  }
+
+  func resolveDate(from text: String, referenceDate: Date) -> Date? {
+    if let explicitDate = parseExplicitDate(from: text) {
+      return explicitDate
+    }
+
+    let normalizedReferenceDate = calendar.startOfDay(for: referenceDate)
+
+    if text.contains("오늘") {
+      return normalizedReferenceDate
+    }
+    if text.contains("내일") {
+      return calendar.date(byAdding: .day, value: 1, to: normalizedReferenceDate)
+    }
+    if text.contains("모레") {
+      return calendar.date(byAdding: .day, value: 2, to: normalizedReferenceDate)
+    }
+
+    guard let targetWeekday = parseWeekday(from: text) else {
+      return normalizedReferenceDate
+    }
+
+    let currentWeekday = calendar.component(.weekday, from: normalizedReferenceDate)
+    var daysToAdd = (targetWeekday - currentWeekday + 7) % 7
+    if daysToAdd == 0 {
+      daysToAdd = 7
+    }
+
+    let hasNextWeekKeyword = text.range(of: "다음\\s*주|담주", options: .regularExpression) != nil
+    if hasNextWeekKeyword {
+      daysToAdd += 7
+    }
+
+    return calendar.date(byAdding: .day, value: daysToAdd, to: normalizedReferenceDate)
+  }
+
+  func parseExplicitDate(from text: String) -> Date? {
+    guard let match = text.firstRegexMatch(pattern: "(\\d{4})[./-](\\d{1,2})[./-](\\d{1,2})"),
+          let year = Int(match[1]),
+          let month = Int(match[2]),
+          let day = Int(match[3])
+    else {
+      return nil
+    }
+
+    var components = DateComponents()
+    components.calendar = calendar
+    components.timeZone = calendar.timeZone
+    components.year = year
+    components.month = month
+    components.day = day
+    return calendar.date(from: components)
+  }
+
+  func parseWeekday(from text: String) -> Int? {
+    let mapping: [String: Int] = [
+      "일": 1,
+      "월": 2,
+      "화": 3,
+      "수": 4,
+      "목": 5,
+      "금": 6,
+      "토": 7,
+    ]
+
+    if let match = text.firstRegexMatch(pattern: "(일|월|화|수|목|금|토)요일") {
+      return mapping[match[1]]
+    }
+    if let match = text.firstRegexMatch(pattern: "(일|월|화|수|목|금|토)요") {
+      return mapping[match[1]]
+    }
+
+    return nil
+  }
+
+  func resolveTime(from text: String) -> String? {
+    if let match = text.firstRegexMatch(pattern: "(오전|오후|아침|점심|저녁|밤)?\\s*(\\d{1,2})\\s*시(?:\\s*(\\d{1,2})\\s*분?)?"),
+       let parsedHour = Int(match[2]) {
+      let meridiem = match[1]
+      let minute = Int(match[3] ?? "") ?? 0
+      guard (0 ..< 60).contains(minute) else {
+        return nil
+      }
+
+      var hour = parsedHour
+      if ["오후", "저녁", "밤"].contains(meridiem), parsedHour < 12 {
+        hour += 12
+      } else if meridiem == "점심", parsedHour < 10 {
+        hour += 12
+      } else if meridiem == "오전", parsedHour == 12 {
+        hour = 0
+      }
+
+      guard (0 ..< 24).contains(hour) else {
+        return nil
+      }
+      return String(format: "%02d:%02d", hour, minute)
+    }
+
+    if let match = text.firstRegexMatch(pattern: "\\b(\\d{1,2}):(\\d{2})\\b"),
+       let hour = Int(match[1]),
+       let minute = Int(match[2]),
+       (0 ..< 24).contains(hour),
+       (0 ..< 60).contains(minute) {
+      return String(format: "%02d:%02d", hour, minute)
+    }
+
+    return nil
+  }
+
+  func resolveDurationMinutes(from text: String) -> Int? {
+    let hourMatch = text.firstRegexMatch(pattern: "(\\d+)\\s*시간")
+    let minuteMatch = text.firstRegexMatch(pattern: "(\\d+)\\s*분")
+
+    let hours = hourMatch.flatMap { Int($0[1]) } ?? 0
+    let minutes = minuteMatch.flatMap { Int($0[1]) } ?? 0
+    let total = (hours * 60) + minutes
+
+    return total > 0 ? total : nil
+  }
+
+  func resolveLocation(from text: String) -> String? {
+    guard let match = text.firstRegexMatch(pattern: "([가-힣A-Za-z0-9\\s]{1,20})에서") else {
+      return nil
+    }
+
+    let location = match[1].trimmingCharacters(in: .whitespacesAndNewlines)
+    return location.isEmpty ? nil : location
+  }
+
+  func resolveTitle(from text: String, location: String?) -> String {
+    var title = text
+    let removalPatterns = [
+      "\\d{4}[./-]\\d{1,2}[./-]\\d{1,2}",
+      "오늘|내일|모레|다음\\s*주|담주",
+      "(일|월|화|수|목|금|토)요일",
+      "(오전|오후|아침|점심|저녁|밤)?\\s*\\d{1,2}\\s*시(?:\\s*\\d{1,2}\\s*분?)?",
+      "\\b\\d{1,2}:\\d{2}\\b",
+      "\\d+\\s*시간",
+      "\\d+\\s*분",
+    ]
+
+    for pattern in removalPatterns {
+      title = title.replacingOccurrences(of: pattern, with: " ", options: .regularExpression)
+    }
+
+    if let location {
+      title = title.replacingOccurrences(of: "\(location)에서", with: " ")
+    }
+
+    title = title.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if title.isEmpty {
+      return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    return title
+  }
+}
+
+private extension String {
+  func firstRegexMatch(pattern: String) -> [String]? {
+    guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+      return nil
+    }
+    let range = NSRange(startIndex ..< endIndex, in: self)
+    guard let match = regex.firstMatch(in: self, options: [], range: range) else {
+      return nil
+    }
+
+    return (0 ..< match.numberOfRanges).compactMap { index in
+      let nsRange = match.range(at: index)
+      guard let range = Range(nsRange, in: self) else {
+        return nil
+      }
+      return String(self[range])
+    }
+  }
+}

--- a/SeukCalendar/AI/AI/FoundationModels/ParsedEventGenerable.swift
+++ b/SeukCalendar/AI/AI/FoundationModels/ParsedEventGenerable.swift
@@ -1,0 +1,15 @@
+#if canImport(FoundationModels)
+  import FoundationModels
+
+  @available(iOS 26.0, macOS 26.0, *)
+  @Generable
+  struct ParsedEventGenerable {
+    let title: String
+    let dateString: String
+    let startTime: String?
+    let durationMinutes: Int?
+    let location: String?
+    let notes: String?
+    let isAllDay: Bool
+  }
+#endif

--- a/SeukCalendar/AI/AITests/AITests.swift
+++ b/SeukCalendar/AI/AITests/AITests.swift
@@ -1,6 +1,7 @@
 @testable import AI
 import Foundation
 import Testing
+internal import CalendarDomain
 
 struct AITests {
   @Test("휴리스틱_내일_오후시간을_절대날짜와_24시간으로_파싱합니다")

--- a/SeukCalendar/AI/AITests/AITests.swift
+++ b/SeukCalendar/AI/AITests/AITests.swift
@@ -1,15 +1,82 @@
-//
-//  AITests.swift
-//  AITests
-//
-//  Created by YoungK on 2/27/26.
-//
-
 @testable import AI
+import Foundation
 import Testing
 
 struct AITests {
-  @Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+  @Test("휴리스틱_내일_오후시간을_절대날짜와_24시간으로_파싱합니다")
+  func parseTomorrowWithTimeByHeuristic() async throws {
+    let parser = FoundationModelsParser(
+      calendar: Self.fixedCalendar,
+      locale: Locale(identifier: "ko_KR"),
+      preferFoundationModels: false
+    )
+
+    let parsed = try await parser.parse(
+      text: "내일 오후 3시 강남역에서 팀 미팅",
+      referenceDate: Self.fixedDate
+    )
+
+    #expect(parsed.dateString == "2026-03-04")
+    #expect(parsed.startTime == "15:00")
+    #expect(parsed.durationMinutes == 60)
+    #expect(parsed.location == "강남역")
+    #expect(parsed.isAllDay == false)
+  }
+
+  @Test("휴리스틱_다음주_금요일_저녁_입력을_파싱합니다")
+  func parseNextWeekFridayEveningByHeuristic() async throws {
+    let parser = FoundationModelsParser(
+      calendar: Self.fixedCalendar,
+      locale: Locale(identifier: "ko_KR"),
+      preferFoundationModels: false
+    )
+
+    let parsed = try await parser.parse(
+      text: "다음주 금요일 저녁 7시 홍대에서 친구들이랑 저녁",
+      referenceDate: Self.fixedDate
+    )
+
+    #expect(parsed.dateString == "2026-03-13")
+    #expect(parsed.startTime == "19:00")
+    #expect(parsed.location == "홍대")
+    #expect(parsed.isAllDay == false)
+  }
+
+  @Test("휴리스틱_시간없는_입력은_종일로_처리합니다")
+  func parseTextWithoutTimeAsAllDayByHeuristic() async throws {
+    let parser = FoundationModelsParser(
+      calendar: Self.fixedCalendar,
+      locale: Locale(identifier: "ko_KR"),
+      preferFoundationModels: false
+    )
+
+    let parsed = try await parser.parse(
+      text: "다음주 월요일 연차",
+      referenceDate: Self.fixedDate
+    )
+
+    #expect(parsed.startTime == nil)
+    #expect(parsed.isAllDay == true)
+    #expect(parsed.durationMinutes == 1440)
+  }
+}
+
+private extension AITests {
+  static var fixedCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+    calendar.locale = Locale(identifier: "ko_KR")
+    return calendar
+  }
+
+  static var fixedDate: Date {
+    let components = DateComponents(
+      calendar: fixedCalendar,
+      timeZone: fixedCalendar.timeZone,
+      year: 2026,
+      month: 3,
+      day: 3
+    )
+    return components.date ?? .init(timeIntervalSince1970: 0)
   }
 }

--- a/SeukCalendar/AI/Module.md
+++ b/SeukCalendar/AI/Module.md
@@ -4,10 +4,9 @@ AI 관련 기능을 제공하는 모듈입니다.
 
 ## 역할
 
-- Foundation Models Framework 통합 (온디바이스 AI)
-- 외부 AI API 연동 (Claude, OpenAI 폴백)
-- Vision Framework OCR 처리
-- Speech Framework 음성 인식
+- Foundation Models 기반 자연어 일정 파싱
+- `CalendarDomain`의 `ScheduleNaturalLanguageParser` 구현 제공
+- Foundation Models 실패/미지원 시 휴리스틱 파싱 폴백 제공
 
 ## 디렉토리 구조
 
@@ -16,137 +15,60 @@ AI/
 ├── AI.xcodeproj
 ├── Module.md
 ├── AI/
-│   ├── FoundationModels/
-│   │   ├── FoundationModelsParser.swift
-│   │   ├── LanguageModelManager.swift
-│   │   └── ParsedEventGenerable.swift
-│   ├── ExternalAPI/
-│   │   ├── ClaudeAPIClient.swift
-│   │   ├── OpenAIAPIClient.swift
-│   │   └── ImagenAPIClient.swift
-│   ├── OCR/
-│   │   ├── VisionOCRProcessor.swift
-│   │   └── OCRResult.swift
-│   └── Speech/
-│       ├── SpeechRecognizer.swift
-│       └── SpeechResult.swift
+│   └── FoundationModels/
+│       ├── FoundationModelsParser.swift
+│       └── ParsedEventGenerable.swift
 └── AITests/
+    └── AITests.swift
 ```
 
 ## 주요 구성요소
 
-### FoundationModels
+### FoundationModelsParser
 
-**역할**: iOS 26+ Foundation Models Framework를 활용한 온디바이스 AI 파싱
+**위치**: `AI/FoundationModels/FoundationModelsParser.swift`
 
-**위치**: `AI/FoundationModels/`
-
-**파일**:
-- FoundationModelsParser.swift: 자연어 → ParsedEvent 파싱
-- LanguageModelManager.swift: LanguageModel 세션 관리
-- ParsedEventGenerable.swift: @Generable 구조체 정의
+**역할**:
+- 사용자 자연어 입력을 `ParsedEvent`로 변환
+- Foundation Models 사용 가능 시 모델 파싱 우선 시도
+- 모델 응답 실패 시 휴리스틱 파싱으로 안전하게 폴백
 
 **주요 기능**:
-- 텍스트 자연어 파싱
-- 날짜/시간 정규화
-- 반복 패턴 인식
-- 프라이버시 보호 (온디바이스 처리)
+- 상대 날짜(`오늘`, `내일`, `다음주 금요일`)를 절대 날짜로 정규화
+- `오전/오후/저녁` 시간을 24시간 형식(`HH:mm`)으로 변환
+- 시간 누락 시 `isAllDay=true` 처리
 
-### ExternalAPI
+### ParsedEventGenerable
 
-**역할**: 외부 AI API 연동 (구형 기기 폴백)
+**위치**: `AI/FoundationModels/ParsedEventGenerable.swift`
 
-**위치**: `AI/ExternalAPI/`
-
-**파일**:
-- ClaudeAPIClient.swift: Anthropic Claude API 클라이언트
-- OpenAIAPIClient.swift: OpenAI GPT API 클라이언트
-- ImagenAPIClient.swift: Google Imagen API 클라이언트 (리캡 이미지 생성)
-
-**주요 기능**:
-- Foundation Models 미지원 기기용 파싱
-- AI 이미지 생성 (데일리 프리뷰, 리캡)
-- API 키 관리 및 에러 핸들링
-
-### OCR
-
-**역할**: Vision Framework를 활용한 이미지 텍스트 인식
-
-**위치**: `AI/OCR/`
-
-**파일**:
-- VisionOCRProcessor.swift: VNRecognizeTextRequest 처리
-- OCRResult.swift: OCR 결과 모델
-
-**주요 기능**:
-- 이미지에서 텍스트 추출
-- 공연 포스터, 스크린샷 파싱
-- 한글/영문 동시 인식
-
-### Speech
-
-**역할**: Speech Framework를 활용한 음성 인식
-
-**위치**: `AI/Speech/`
-
-**파일**:
-- SpeechRecognizer.swift: SFSpeechRecognizer 래퍼
-- SpeechResult.swift: 음성 인식 결과 모델
-
-**주요 기능**:
-- 실시간 음성 → 텍스트 변환
-- 권한 요청 및 처리
-- 에러 핸들링
+**역할**:
+- Foundation Models의 구조화 출력용 `@Generable` 모델 정의
 
 ## 의존성
 
-- **Core**: 공통 유틸리티
-- **Domain**: ParsingDomain (ParsedEvent 모델 사용)
+- **Core**: 공통 에러 프로토콜(`SCError`)
+- **Domain**: `ParsedEvent`, `ScheduleNaturalLanguageParser`
 
 ## Xcode 프로젝트 설정
 
 **위치**: `AI.xcodeproj`
 
 **주요 설정**:
-- 플랫폼: iOS 18+
+- 플랫폼: iOS 26+
 - 프레임워크 타입: Dynamic Framework
-- 의존성: Core.framework, ParsingDomain.framework
+- 의존성: Core.framework, CalendarDomain.framework, UserDomain.framework
 - 타겟: AI (Framework), AITests (Unit Test)
 
 ## 사용 가이드
 
-### Foundation Models 파싱
-
-**참고**: `AI/FoundationModels/FoundationModelsParser.swift`
-
 ```swift
-let parser = FoundationModelsParser()
-let parsedEvent = try await parser.parse(text: "내일 오후 3시 강남역 미팅")
-```
+import AI
+import CalendarDomain
 
-### 외부 API 파싱 (폴백)
-
-**참고**: `AI/ExternalAPI/ClaudeAPIClient.swift`
-
-```swift
-let client = ClaudeAPIClient()
-let parsedEvent = try await client.parseEvent(text: "내일 오후 3시 강남역 미팅")
-```
-
-### OCR 처리
-
-**참고**: `AI/OCR/VisionOCRProcessor.swift`
-
-```swift
-let processor = VisionOCRProcessor()
-let ocrResult = try await processor.recognizeText(from: image)
-```
-
-### 음성 인식
-
-**참고**: `AI/Speech/SpeechRecognizer.swift`
-
-```swift
-let recognizer = SpeechRecognizer()
-try await recognizer.startRecording()
+let parser: any ScheduleNaturalLanguageParser = FoundationModelsParser()
+let parsed = try await parser.parse(
+  text: "다음주 화요일 오후 2시에 강남역에서 팀 미팅",
+  referenceDate: Date()
+)
 ```

--- a/SeukCalendar/DesignSystem/DesignSystem/ResourceSystem/ImageSystem/Icon.swift
+++ b/SeukCalendar/DesignSystem/DesignSystem/ResourceSystem/ImageSystem/Icon.swift
@@ -54,7 +54,6 @@ public enum Icon {
   public static let comment = ImageResource(name: "ico-comment")
   public static let commentFill = ImageResource(name: "ico-comment-fill")
   public static let share = ImageResource(name: "ico-share")
-  #warning("나중에 어디로 옮기지 고민")
   public static let logo = ImageResource(name: "logo")
 }
 

--- a/SeukCalendar/Domain/CalendarDomain/Entity/ParsedEvent.swift
+++ b/SeukCalendar/Domain/CalendarDomain/Entity/ParsedEvent.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct ParsedEvent: Equatable, Sendable {
+  public var title: String
+  public var dateString: String
+  public var startTime: String?
+  public var durationMinutes: Int?
+  public var location: String?
+  public var notes: String?
+  public var isAllDay: Bool
+
+  public init(
+    title: String,
+    dateString: String,
+    startTime: String?,
+    durationMinutes: Int?,
+    location: String?,
+    notes: String?,
+    isAllDay: Bool
+  ) {
+    self.title = title
+    self.dateString = dateString
+    self.startTime = startTime
+    self.durationMinutes = durationMinutes
+    self.location = location
+    self.notes = notes
+    self.isAllDay = isAllDay
+  }
+}

--- a/SeukCalendar/Domain/CalendarDomain/Repository/ScheduleNaturalLanguageParser.swift
+++ b/SeukCalendar/Domain/CalendarDomain/Repository/ScheduleNaturalLanguageParser.swift
@@ -1,0 +1,42 @@
+import Core
+import Foundation
+
+public enum ScheduleNaturalLanguageParserError: SCError, Equatable {
+  case unsupported
+  case emptyInput
+  case parsingFailed
+
+  public var errorDescription: String {
+    switch self {
+    case .unsupported:
+      "자연어 파서를 사용할 수 없는 환경입니다."
+    case .emptyInput:
+      "파싱할 입력 문자열이 비어 있습니다."
+    case .parsingFailed:
+      "자연어 입력을 일정으로 해석하지 못했습니다."
+    }
+  }
+
+  public var userMessage: String {
+    switch self {
+    case .unsupported:
+      "현재 기기에서는 AI 파싱을 사용할 수 없습니다."
+    case .emptyInput:
+      "일정 문장을 입력해주세요."
+    case .parsingFailed:
+      "입력한 문장을 일정으로 해석하지 못했습니다. 내용을 조금 더 구체적으로 입력해주세요."
+    }
+  }
+}
+
+public protocol ScheduleNaturalLanguageParser {
+  func parse(text: String, referenceDate: Date) async throws -> ParsedEvent
+}
+
+public struct UnavailableScheduleNaturalLanguageParser: ScheduleNaturalLanguageParser {
+  public init() {}
+
+  public func parse(text: String, referenceDate: Date) async throws -> ParsedEvent {
+    throw ScheduleNaturalLanguageParserError.unsupported
+  }
+}

--- a/SeukCalendar/Domain/CalendarDomain/UseCase/ParseEventUseCase.swift
+++ b/SeukCalendar/Domain/CalendarDomain/UseCase/ParseEventUseCase.swift
@@ -1,0 +1,139 @@
+import Core
+import Foundation
+
+public enum ParseEventUseCaseError: SCError, Equatable {
+  case emptyInput
+  case invalidDateFormat
+  case invalidTimeFormat
+
+  public var errorDescription: String {
+    switch self {
+    case .emptyInput:
+      "파싱할 입력 문자열이 비어 있습니다."
+    case .invalidDateFormat:
+      "파싱 결과의 날짜 형식이 올바르지 않습니다."
+    case .invalidTimeFormat:
+      "파싱 결과의 시간 형식이 올바르지 않습니다."
+    }
+  }
+
+  public var userMessage: String {
+    switch self {
+    case .emptyInput:
+      "일정 문장을 입력해주세요."
+    case .invalidDateFormat:
+      "날짜를 확인할 수 없어 일정을 저장하지 못했습니다."
+    case .invalidTimeFormat:
+      "시간 형식이 올바르지 않아 일정을 저장하지 못했습니다."
+    }
+  }
+}
+
+public struct ParseEventUseCase {
+  private let parser: any ScheduleNaturalLanguageParser
+  private let calendar: Calendar
+
+  public init(
+    parser: any ScheduleNaturalLanguageParser,
+    calendar: Calendar = .current
+  ) {
+    self.parser = parser
+    self.calendar = calendar
+  }
+
+  public func execute(
+    text: String,
+    referenceDate: Date = Date()
+  ) async throws -> ParsedEvent {
+    let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedText.isEmpty else {
+      throw ParseEventUseCaseError.emptyInput
+    }
+
+    return try await parser.parse(text: trimmedText, referenceDate: referenceDate)
+  }
+
+  public func toSchedule(from parsedEvent: ParsedEvent) throws -> Schedule {
+    guard let parsedDate = parsedDate(from: parsedEvent.dateString) else {
+      throw ParseEventUseCaseError.invalidDateFormat
+    }
+
+    var dateComponents = calendar.dateComponents([.year, .month, .day], from: parsedDate)
+    dateComponents.calendar = calendar
+    dateComponents.timeZone = calendar.timeZone
+
+    let hasTime = !(parsedEvent.startTime?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+    let isAllDay = parsedEvent.isAllDay || !hasTime
+
+    let timeComponents: DateComponents?
+    if isAllDay {
+      timeComponents = nil
+    } else {
+      guard let startTime = parsedEvent.startTime else {
+        throw ParseEventUseCaseError.invalidTimeFormat
+      }
+      timeComponents = try parsedTime(from: startTime)
+    }
+
+    let defaultDurationMinutes = isAllDay ? 1440 : 60
+    let durationMinutes = max(parsedEvent.durationMinutes ?? defaultDurationMinutes, isAllDay ? 1440 : 1)
+    let durationSeconds = TimeInterval(durationMinutes * 60)
+
+    let title = parsedEvent.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let location = parsedEvent.location?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let notes = parsedEvent.notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    return Schedule(
+      title: title.isEmpty ? "제목 없음" : title,
+      date: dateComponents,
+      time: timeComponents,
+      duration: durationSeconds,
+      location: location?.isEmpty == true ? nil : location,
+      notes: notes?.isEmpty == true ? nil : notes,
+      isAllDay: isAllDay
+    )
+  }
+}
+
+private extension ParseEventUseCase {
+  func parsedDate(from dateString: String) -> Date? {
+    let formats = ["yyyy-MM-dd", "yyyy.MM.dd", "yyyy/MM/dd"]
+
+    for format in formats {
+      let formatter = DateFormatter()
+      formatter.calendar = calendar
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = calendar.timeZone
+      formatter.dateFormat = format
+
+      if let parsedDate = formatter.date(from: dateString) {
+        return parsedDate
+      }
+    }
+
+    return nil
+  }
+
+  func parsedTime(from timeString: String) throws -> DateComponents {
+    let sanitized = timeString
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: " ", with: "")
+    let parts = sanitized.split(separator: ":", omittingEmptySubsequences: false)
+
+    guard parts.count == 2,
+          let hour = Int(parts[0]),
+          let minute = Int(parts[1]),
+          (0 ..< 24).contains(hour),
+          (0 ..< 60).contains(minute)
+    else {
+      throw ParseEventUseCaseError.invalidTimeFormat
+    }
+
+    var components = DateComponents()
+    components.calendar = calendar
+    components.timeZone = calendar.timeZone
+    components.hour = hour
+    components.minute = minute
+    return components
+  }
+}

--- a/SeukCalendar/Domain/CalendarDomainTestSupport/MockScheduleNaturalLanguageParser.swift
+++ b/SeukCalendar/Domain/CalendarDomainTestSupport/MockScheduleNaturalLanguageParser.swift
@@ -1,0 +1,26 @@
+import CalendarDomain
+import Foundation
+
+public final class MockScheduleNaturalLanguageParser: ScheduleNaturalLanguageParser {
+  public var parseResult: Result<ParsedEvent, Error> = .success(
+    ParsedEvent(
+      title: "기본 파싱 일정",
+      dateString: "2026-03-03",
+      startTime: "10:00",
+      durationMinutes: 60,
+      location: nil,
+      notes: nil,
+      isAllDay: false
+    )
+  )
+  public private(set) var parseCallCount = 0
+  public private(set) var parsedInputs: [(text: String, referenceDate: Date)] = []
+
+  public init() {}
+
+  public func parse(text: String, referenceDate: Date) async throws -> ParsedEvent {
+    parseCallCount += 1
+    parsedInputs.append((text, referenceDate))
+    return try parseResult.get()
+  }
+}

--- a/SeukCalendar/Domain/CalendarDomainTests/CalendarDomainTests.swift
+++ b/SeukCalendar/Domain/CalendarDomainTests/CalendarDomainTests.swift
@@ -12,7 +12,7 @@ struct CalendarDomainTests {
       title: "신규 일정",
       date: DateComponents(year: 2026, month: 3, day: 3),
       time: DateComponents(hour: 9, minute: 30),
-      duration: 3_600,
+      duration: 3600,
       location: "서울",
       notes: "메모",
       isAllDay: false,
@@ -43,7 +43,7 @@ struct CalendarDomainTests {
     let useCase = FetchSchedulesUseCase(repository: repository)
     let range = DateInterval(
       start: Date(timeIntervalSince1970: 0),
-      end: Date(timeIntervalSince1970: 86_400)
+      end: Date(timeIntervalSince1970: 86400)
     )
 
     let schedules = try await useCase.execute(in: range)
@@ -74,5 +74,80 @@ struct CalendarDomainTests {
     try await useCase.execute(id: id)
 
     #expect(repository.deletedScheduleIDs == [id])
+  }
+
+  @Test("ParseEventUseCase_execute_파서를_호출합니다")
+  func parseEventUseCaseCallsParser() async throws {
+    let parser = MockScheduleNaturalLanguageParser()
+    let useCase = ParseEventUseCase(parser: parser, calendar: Self.fixedCalendar)
+    let input = "내일 오후 3시 회의"
+
+    _ = try await useCase.execute(text: input, referenceDate: Self.fixedDate)
+
+    #expect(parser.parseCallCount == 1)
+    #expect(parser.parsedInputs.first?.text == input)
+  }
+
+  @Test("ParseEventUseCase_toSchedule_시간있는_일정을_생성합니다")
+  func parseEventUseCaseCreatesTimedScheduleFromParsedEvent() throws {
+    let parser = MockScheduleNaturalLanguageParser()
+    let useCase = ParseEventUseCase(parser: parser, calendar: Self.fixedCalendar)
+    let parsedEvent = ParsedEvent(
+      title: "팀 미팅",
+      dateString: "2026-03-10",
+      startTime: "15:30",
+      durationMinutes: 90,
+      location: "강남역",
+      notes: "준비물 확인",
+      isAllDay: false
+    )
+
+    let schedule = try useCase.toSchedule(from: parsedEvent)
+
+    #expect(schedule.isAllDay == false)
+    #expect(schedule.time?.hour == 15)
+    #expect(schedule.time?.minute == 30)
+    #expect(schedule.duration == 5400)
+    #expect(schedule.location == "강남역")
+  }
+
+  @Test("ParseEventUseCase_toSchedule_시간이_없으면_종일로_처리합니다")
+  func parseEventUseCaseTreatsNoTimeAsAllDay() throws {
+    let parser = MockScheduleNaturalLanguageParser()
+    let useCase = ParseEventUseCase(parser: parser, calendar: Self.fixedCalendar)
+    let parsedEvent = ParsedEvent(
+      title: "연차",
+      dateString: "2026-03-11",
+      startTime: nil,
+      durationMinutes: nil,
+      location: nil,
+      notes: nil,
+      isAllDay: false
+    )
+
+    let schedule = try useCase.toSchedule(from: parsedEvent)
+
+    #expect(schedule.isAllDay == true)
+    #expect(schedule.time == nil)
+    #expect(schedule.duration == 86400)
+  }
+}
+
+private extension CalendarDomainTests {
+  static var fixedCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+    return calendar
+  }
+
+  static var fixedDate: Date {
+    let components = DateComponents(
+      calendar: fixedCalendar,
+      timeZone: fixedCalendar.timeZone,
+      year: 2026,
+      month: 3,
+      day: 3
+    )
+    return components.date ?? .init(timeIntervalSince1970: 0)
   }
 }

--- a/SeukCalendar/Domain/Module.md
+++ b/SeukCalendar/Domain/Module.md
@@ -7,6 +7,7 @@
 - 비즈니스 로직 캡슐화
 - 순수 도메인 엔티티 정의
 - Repository 인터페이스 제공 (Data Layer와의 계약)
+- AI 파서 인터페이스와 파싱 결과 → Schedule 변환 규칙 제공
 - 도메인 Service 구현
 
 ## 디렉토리 구조
@@ -37,15 +38,18 @@ Domain/
 
 **Entity**: `CalendarDomain/Entity/`
 - `Schedule.swift`: 일정 도메인 모델 (title, date/time, duration, recurrence)
+- `ParsedEvent.swift`: AI 자연어 파싱 결과 모델 (dateString/startTime/isAllDay 등)
 
 **UseCase**: `CalendarDomain/UseCase/`
 - `CreateScheduleUseCase.swift`: 일정 생성
 - `FetchSchedulesUseCase.swift`: 일정 단건/기간 조회
 - `UpdateScheduleUseCase.swift`: 일정 수정
 - `DeleteScheduleUseCase.swift`: 일정 삭제
+- `ParseEventUseCase.swift`: 자연어 파싱 실행 및 `ParsedEvent` → `Schedule` 변환
 
 **Repository**: `CalendarDomain/Repository/`
 - `ScheduleRepository.swift`: EventKit 기반 저장소와의 계약 인터페이스
+- `ScheduleNaturalLanguageParser.swift`: AI 파서 구현체와의 계약 인터페이스
 
 **Service**: `CalendarDomain/Service/`
 
@@ -111,4 +115,5 @@ Domain/
 ### Mock 사용
 
 - **CalendarDomain 참고**: `CalendarDomainTestSupport/MockScheduleRepository.swift`
+- **AI 파싱 Mock 참고**: `CalendarDomainTestSupport/MockScheduleNaturalLanguageParser.swift`
 - **UserDomain 참고**: `UserDomainTestSupport/` (현재 Mock 없음)

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
@@ -13,6 +13,7 @@ public struct CalendarView: View {
   public var body: some View {
     NavigationStack(path: $path) {
       VStack(spacing: 16) {
+        aiParsingSection
         modePicker
         dateHeader
         permissionDescription
@@ -34,7 +35,7 @@ public struct CalendarView: View {
       .navigationTitle("캘린더")
       .navigationBarTitleDisplayMode(.inline)
       .overlay {
-        if viewModel.isLoading {
+        if viewModel.isLoading || viewModel.isParsingNaturalLanguage || viewModel.isSavingParsedEvent {
           ProgressView()
             .padding(20)
             .background(.ultraThinMaterial)
@@ -52,6 +53,99 @@ public struct CalendarView: View {
 }
 
 private extension CalendarView {
+  var aiParsingSection: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("AI 일정 파싱")
+        .font(.system(size: 15, weight: .semibold))
+
+      TextField(
+        "예: 다음주 화요일 오후 2시에 강남역에서 팀장님 미팅",
+        text: naturalLanguageInputBinding,
+        axis: .vertical
+      )
+      .textFieldStyle(.roundedBorder)
+      .lineLimit(2 ... 4)
+
+      HStack(spacing: 8) {
+        Button("파싱") {
+          viewModel.send(.parseNaturalLanguage)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(viewModel.naturalLanguageInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        if viewModel.parsedEventDraft != nil {
+          Button("초기화") {
+            viewModel.send(.clearParsedEvent)
+          }
+          .buttonStyle(.bordered)
+        }
+      }
+
+      if let parseErrorMessage = viewModel.parseErrorMessage {
+        Text(parseErrorMessage)
+          .font(.system(size: 12, weight: .regular))
+          .foregroundStyle(.red)
+      }
+
+      if let parserStatusMessage = viewModel.parserStatusMessage {
+        Text(parserStatusMessage)
+          .font(.system(size: 12, weight: .regular))
+          .foregroundStyle(.green)
+      }
+
+      if viewModel.parsedEventDraft != nil {
+        parsedEventEditorCard
+      }
+    }
+    .padding(12)
+    .background(Color(.secondarySystemBackground))
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+  }
+
+  var parsedEventEditorCard: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("파싱 결과 확인/수정")
+        .font(.system(size: 14, weight: .semibold))
+
+      TextField("제목", text: parsedTitleBinding)
+        .textFieldStyle(.roundedBorder)
+
+      TextField("날짜 (yyyy-MM-dd)", text: parsedDateStringBinding)
+        .textFieldStyle(.roundedBorder)
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled()
+
+      Toggle("종일 일정", isOn: parsedIsAllDayBinding)
+
+      if !(viewModel.parsedEventDraft?.isAllDay ?? true) {
+        TextField("시작 시간 (HH:mm)", text: parsedStartTimeBinding)
+          .textFieldStyle(.roundedBorder)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+      }
+
+      TextField("소요 시간(분)", text: parsedDurationMinutesBinding)
+        .textFieldStyle(.roundedBorder)
+        .keyboardType(.numberPad)
+
+      TextField("장소", text: parsedLocationBinding)
+        .textFieldStyle(.roundedBorder)
+
+      TextField("메모", text: parsedNotesBinding, axis: .vertical)
+        .textFieldStyle(.roundedBorder)
+        .lineLimit(2 ... 4)
+
+      Button("일정 저장") {
+        viewModel.send(.saveParsedEvent)
+      }
+      .buttonStyle(.borderedProminent)
+      .disabled(viewModel.parsedEventDraft == nil)
+    }
+    .padding(12)
+    .background(Color(.systemBackground))
+    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+  }
+
   var modePicker: some View {
     Picker("뷰 모드", selection: modeBinding) {
       ForEach(CalendarViewModel.ViewMode.allCases) { mode in
@@ -174,6 +268,62 @@ private extension CalendarView {
       set: { mode in
         viewModel.send(.changeMode(mode))
       }
+    )
+  }
+
+  var naturalLanguageInputBinding: Binding<String> {
+    Binding(
+      get: { viewModel.naturalLanguageInput },
+      set: { viewModel.send(.updateNaturalLanguageInput($0)) }
+    )
+  }
+
+  var parsedTitleBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.title ?? "" },
+      set: { viewModel.send(.updateParsedTitle($0)) }
+    )
+  }
+
+  var parsedDateStringBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.dateString ?? "" },
+      set: { viewModel.send(.updateParsedDateString($0)) }
+    )
+  }
+
+  var parsedStartTimeBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.startTime ?? "" },
+      set: { viewModel.send(.updateParsedStartTime($0)) }
+    )
+  }
+
+  var parsedDurationMinutesBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.durationMinutesText ?? "" },
+      set: { viewModel.send(.updateParsedDurationMinutes($0)) }
+    )
+  }
+
+  var parsedLocationBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.location ?? "" },
+      set: { viewModel.send(.updateParsedLocation($0)) }
+    )
+  }
+
+  var parsedNotesBinding: Binding<String> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.notes ?? "" },
+      set: { viewModel.send(.updateParsedNotes($0)) }
+    )
+  }
+
+  var parsedIsAllDayBinding: Binding<Bool> {
+    Binding(
+      get: { viewModel.parsedEventDraft?.isAllDay ?? true },
+      set: { viewModel.send(.updateParsedIsAllDay($0)) }
     )
   }
 

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Action.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Action.swift
@@ -7,5 +7,16 @@ public extension CalendarViewModel {
     case selectDate(Date)
     case movePeriod(Int)
     case moveToToday
+    case updateNaturalLanguageInput(String)
+    case parseNaturalLanguage
+    case clearParsedEvent
+    case updateParsedTitle(String)
+    case updateParsedDateString(String)
+    case updateParsedStartTime(String)
+    case updateParsedDurationMinutes(String)
+    case updateParsedLocation(String)
+    case updateParsedNotes(String)
+    case updateParsedIsAllDay(Bool)
+    case saveParsedEvent
   }
 }

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Model.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Model.swift
@@ -1,3 +1,6 @@
+import CalendarDomain
+import Foundation
+
 public extension CalendarViewModel {
   enum ViewMode: String, CaseIterable, Identifiable {
     case month
@@ -29,6 +32,60 @@ public extension CalendarViewModel {
       }
 
       return false
+    }
+  }
+
+  struct ParsedEventDraft: Equatable {
+    public var title: String
+    public var dateString: String
+    public var startTime: String
+    public var durationMinutesText: String
+    public var location: String
+    public var notes: String
+    public var isAllDay: Bool
+
+    public init(
+      title: String,
+      dateString: String,
+      startTime: String,
+      durationMinutesText: String,
+      location: String,
+      notes: String,
+      isAllDay: Bool
+    ) {
+      self.title = title
+      self.dateString = dateString
+      self.startTime = startTime
+      self.durationMinutesText = durationMinutesText
+      self.location = location
+      self.notes = notes
+      self.isAllDay = isAllDay
+    }
+
+    init(parsedEvent: ParsedEvent) {
+      self.title = parsedEvent.title
+      self.dateString = parsedEvent.dateString
+      self.startTime = parsedEvent.startTime ?? ""
+      if let durationMinutes = parsedEvent.durationMinutes {
+        self.durationMinutesText = String(durationMinutes)
+      } else {
+        self.durationMinutesText = ""
+      }
+      self.location = parsedEvent.location ?? ""
+      self.notes = parsedEvent.notes ?? ""
+      self.isAllDay = parsedEvent.isAllDay
+    }
+
+    var parsedEvent: ParsedEvent {
+      ParsedEvent(
+        title: title,
+        dateString: dateString,
+        startTime: startTime.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : startTime,
+        durationMinutes: Int(durationMinutesText),
+        location: location.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : location,
+        notes: notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : notes,
+        isAllDay: isAllDay
+      )
     }
   }
 }

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift
@@ -1,4 +1,5 @@
 import CalendarDomain
+import Core
 import DesignSystem
 import Foundation
 import Observation
@@ -12,7 +13,16 @@ public final class CalendarViewModel {
   public private(set) var isLoading = false
   public private(set) var visibleEvents: [CalendarEvent] = []
 
+  public private(set) var naturalLanguageInput = ""
+  public private(set) var parsedEventDraft: ParsedEventDraft?
+  public private(set) var parseErrorMessage: String?
+  public private(set) var parserStatusMessage: String?
+  public private(set) var isParsingNaturalLanguage = false
+  public private(set) var isSavingParsedEvent = false
+
   private let repository: any ScheduleRepository
+  private let parseEventUseCase: ParseEventUseCase
+  private let createScheduleUseCase: CreateScheduleUseCase
   private let calendar: Calendar
   private var hasLoaded = false
   private var pendingActionTask: Task<Void, Never>?
@@ -21,12 +31,15 @@ public final class CalendarViewModel {
     selectedDate: Date = Date(),
     viewMode: ViewMode = .month,
     calendar: Calendar = .current,
-    repository: any ScheduleRepository
+    repository: any ScheduleRepository,
+    parser: any ScheduleNaturalLanguageParser = UnavailableScheduleNaturalLanguageParser()
   ) {
     self.selectedDate = calendar.startOfDay(for: selectedDate)
     self.viewMode = viewMode
     self.calendar = calendar
     self.repository = repository
+    parseEventUseCase = ParseEventUseCase(parser: parser, calendar: calendar)
+    createScheduleUseCase = CreateScheduleUseCase(repository: repository)
   }
 
   @discardableResult
@@ -104,6 +117,38 @@ private extension CalendarViewModel {
       await handleMovePeriod(offset)
     case .moveToToday:
       await handleMoveToToday()
+    case let .updateNaturalLanguageInput(text):
+      handleUpdateNaturalLanguageInput(text)
+    case .parseNaturalLanguage:
+      await handleParseNaturalLanguage()
+    case .clearParsedEvent:
+      handleClearParsedEvent()
+    case let .updateParsedTitle(title):
+      updateParsedDraft { $0.title = title }
+    case let .updateParsedDateString(dateString):
+      updateParsedDraft { $0.dateString = dateString }
+    case let .updateParsedStartTime(startTime):
+      updateParsedDraft {
+        $0.startTime = startTime
+        if !startTime.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          $0.isAllDay = false
+        }
+      }
+    case let .updateParsedDurationMinutes(durationMinutes):
+      updateParsedDraft { $0.durationMinutesText = durationMinutes }
+    case let .updateParsedLocation(location):
+      updateParsedDraft { $0.location = location }
+    case let .updateParsedNotes(notes):
+      updateParsedDraft { $0.notes = notes }
+    case let .updateParsedIsAllDay(isAllDay):
+      updateParsedDraft {
+        $0.isAllDay = isAllDay
+        if isAllDay {
+          $0.startTime = ""
+        }
+      }
+    case .saveParsedEvent:
+      await handleSaveParsedEvent()
     }
   }
 
@@ -133,6 +178,76 @@ private extension CalendarViewModel {
   func handleMoveToToday() async {
     selectedDate = calendar.startOfDay(for: Date())
     await reloadVisibleEvents()
+  }
+
+  func handleUpdateNaturalLanguageInput(_ text: String) {
+    naturalLanguageInput = text
+    parseErrorMessage = nil
+    parserStatusMessage = nil
+  }
+
+  func handleParseNaturalLanguage() async {
+    parseErrorMessage = nil
+    parserStatusMessage = nil
+    isParsingNaturalLanguage = true
+    defer { isParsingNaturalLanguage = false }
+
+    do {
+      let parsedEvent = try await parseEventUseCase.execute(
+        text: naturalLanguageInput,
+        referenceDate: selectedDate
+      )
+      parsedEventDraft = ParsedEventDraft(parsedEvent: parsedEvent)
+      parserStatusMessage = "파싱 결과를 확인하고 필요한 값을 수정한 뒤 저장해주세요."
+    } catch {
+      parsedEventDraft = nil
+      parseErrorMessage = userMessage(for: error)
+    }
+  }
+
+  func handleClearParsedEvent() {
+    parsedEventDraft = nil
+    parseErrorMessage = nil
+    parserStatusMessage = nil
+  }
+
+  func handleSaveParsedEvent() async {
+    guard let parsedEventDraft else {
+      return
+    }
+
+    parseErrorMessage = nil
+    parserStatusMessage = nil
+    isSavingParsedEvent = true
+    defer { isSavingParsedEvent = false }
+
+    let isAuthorized = await ensureCalendarPermission()
+    guard isAuthorized else {
+      return
+    }
+
+    do {
+      let schedule = try parseEventUseCase.toSchedule(from: parsedEventDraft.parsedEvent)
+      _ = try await createScheduleUseCase.execute(schedule: schedule)
+
+      naturalLanguageInput = ""
+      self.parsedEventDraft = nil
+      parserStatusMessage = "일정을 저장했습니다."
+      await reloadVisibleEvents()
+    } catch {
+      parseErrorMessage = userMessage(for: error)
+    }
+  }
+
+  func updateParsedDraft(_ transform: (inout ParsedEventDraft) -> Void) {
+    guard var draft = parsedEventDraft else {
+      return
+    }
+
+    transform(&draft)
+    parsedEventDraft = draft
+    parseErrorMessage = nil
+    parserStatusMessage = nil
   }
 
   func shouldReloadAfterSelectingDate(from previousDate: Date, to currentDate: Date) -> Bool {
@@ -291,5 +406,13 @@ private extension CalendarViewModel {
       location: schedule.location,
       notes: schedule.notes
     )
+  }
+
+  func userMessage(for error: Error) -> String {
+    if let scError = error as? any SCError {
+      return scError.userMessage
+    }
+
+    return "일정을 처리하지 못했습니다. 잠시 후 다시 시도해주세요."
   }
 }

--- a/SeukCalendar/Feature/CalendarFeature/CalendarViewFactory.swift
+++ b/SeukCalendar/Feature/CalendarFeature/CalendarViewFactory.swift
@@ -4,13 +4,18 @@ import SwiftUI
 @MainActor
 public struct CalendarViewFactory {
   private let repository: any ScheduleRepository
+  private let parser: any ScheduleNaturalLanguageParser
 
-  public init(repository: any ScheduleRepository) {
+  public init(
+    repository: any ScheduleRepository,
+    parser: any ScheduleNaturalLanguageParser = UnavailableScheduleNaturalLanguageParser()
+  ) {
     self.repository = repository
+    self.parser = parser
   }
 
   @ViewBuilder
   public func makeCalendarView() -> some View {
-    CalendarView(viewModel: CalendarViewModel(repository: repository))
+    CalendarView(viewModel: CalendarViewModel(repository: repository, parser: parser))
   }
 }

--- a/SeukCalendar/Feature/CalendarFeatureTests/CalendarFeatureTests.swift
+++ b/SeukCalendar/Feature/CalendarFeatureTests/CalendarFeatureTests.swift
@@ -1,6 +1,6 @@
-@testable import CalendarFeature
 import CalendarDomain
 import CalendarDomainTestSupport
+@testable import CalendarFeature
 import Foundation
 import Testing
 
@@ -111,6 +111,76 @@ struct CalendarFeatureTests {
 
     #expect(viewModel.eventsByDay[firstDay]?.count == 1)
     #expect(viewModel.eventsByDay[secondDay]?.count == 1)
+  }
+
+  @Test("parseNaturalLanguage_성공시_편집용_초안을_설정합니다")
+  @MainActor
+  func parseNaturalLanguageSetsDraftWhenSucceeded() async {
+    let mockRepository = MockScheduleRepository()
+    let mockParser = MockScheduleNaturalLanguageParser()
+    mockParser.parseResult = .success(
+      ParsedEvent(
+        title: "팀 미팅",
+        dateString: "2026-03-04",
+        startTime: "15:00",
+        durationMinutes: 60,
+        location: "강남역",
+        notes: "자료 준비",
+        isAllDay: false
+      )
+    )
+    let viewModel = CalendarViewModel(
+      selectedDate: Self.fixedDate,
+      viewMode: .month,
+      calendar: Self.fixedCalendar,
+      repository: mockRepository,
+      parser: mockParser
+    )
+
+    await viewModel.send(.updateNaturalLanguageInput("내일 오후 3시 강남역에서 팀 미팅")).value
+    await viewModel.send(.parseNaturalLanguage).value
+
+    #expect(mockParser.parseCallCount == 1)
+    #expect(viewModel.parsedEventDraft?.title == "팀 미팅")
+    #expect(viewModel.parsedEventDraft?.dateString == "2026-03-04")
+    #expect(viewModel.parseErrorMessage == nil)
+  }
+
+  @Test("saveParsedEvent_저장시_일정을_생성하고_목록을_갱신합니다")
+  @MainActor
+  func saveParsedEventCreatesScheduleAndReloadsEvents() async {
+    let mockRepository = MockScheduleRepository()
+    mockRepository.authorizationStatusValue = .fullAccess
+    let mockParser = MockScheduleNaturalLanguageParser()
+    mockParser.parseResult = .success(
+      ParsedEvent(
+        title: "팀 미팅",
+        dateString: "2026-03-04",
+        startTime: "15:00",
+        durationMinutes: 60,
+        location: "강남역",
+        notes: nil,
+        isAllDay: false
+      )
+    )
+
+    let viewModel = CalendarViewModel(
+      selectedDate: Self.fixedDate,
+      viewMode: .month,
+      calendar: Self.fixedCalendar,
+      repository: mockRepository,
+      parser: mockParser
+    )
+
+    await viewModel.send(.updateNaturalLanguageInput("내일 오후 3시 강남역에서 팀 미팅")).value
+    await viewModel.send(.parseNaturalLanguage).value
+    await viewModel.send(.saveParsedEvent).value
+
+    #expect(mockRepository.createdSchedules.count == 2)
+    #expect(mockRepository.createdSchedules.last?.title == "팀 미팅")
+    #expect(viewModel.parsedEventDraft == nil)
+    #expect(viewModel.naturalLanguageInput.isEmpty)
+    #expect(viewModel.visibleEvents.isEmpty == false)
   }
 }
 

--- a/SeukCalendar/Feature/Module.md
+++ b/SeukCalendar/Feature/Module.md
@@ -47,13 +47,13 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 - CalendarView.swift: Calendar View
 - CalendarViewModel.swift: Calendar ViewModel (@Observable)
 - CalendarViewModel+Action.swift: ViewModel Action enum 분리
-- CalendarViewModel+Model.swift: ViewModel 보조 enum(ViewMode/PermissionState) 분리
+- CalendarViewModel+Model.swift: ViewModel 보조 enum/모델(ViewMode/PermissionState/ParsedEventDraft) 분리
 - Components/ScheduleDetailView.swift: 일정 상세 화면
 
 **ViewFactory**: `CalendarFeature/CalendarViewFactory.swift`
 - 화면 생성 팩토리
 - `CalendarViewModel` 생성/주입 책임 보유 (`CalendarView`는 필수 주입만 허용)
-- DIContainer 도입 전까지 `makeCalendarView()` 내부에서 전달받은 `ScheduleRepository`로 `CalendarViewModel`을 생성
+- DIContainer 도입 전까지 `makeCalendarView()` 내부에서 전달받은 `ScheduleRepository`와 `ScheduleNaturalLanguageParser`로 `CalendarViewModel`을 생성
 
 **구현 참고**:
 - ViewModel: `CalendarFeature/Calendar/CalendarViewModel.swift`
@@ -102,7 +102,7 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 
 **주요 구성**:
 - Properties: 의존성, 공개 상태, 비공개 상태
-- Action: Lifecycle, ViewAction으로 구분
+- Action: 캘린더 탐색 액션 + 자연어 파싱/저장 액션
 - send(_:): Action 처리
 
 **ViewModel 파일 구조 표준**:
@@ -120,6 +120,7 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 - @State로 ViewModel 보유
 - .send()로 Action 전달
 - ViewModel의 공개 상태 구독
+- 자연어 입력 필드 + 파싱 결과 편집 카드 + 저장 버튼 UI 포함
 
 ### ViewFactory
 

--- a/SeukCalendar/Navigation/Navigation/Router.swift
+++ b/SeukCalendar/Navigation/Navigation/Router.swift
@@ -83,7 +83,6 @@ public extension Router {
     }
   }
 
-#warning("영규님 dismiss나 pop 말고 진입하는건 통합으로 하고 나머지는 private으로 하는게 어떨까요?? 외부 공개 범위가 넓은 듯?")
   /// 탭 선택 (자식 → 부모 → 루트로 전송)
   func select(tab destination: TabDestination) {
     if level == 0 {

--- a/SeukCalendar/SeukCalendar/ContentView.swift
+++ b/SeukCalendar/SeukCalendar/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by YoungK on 2/27/26.
 //
 
+import AI
 import CalendarData
 import CalendarDomain
 import CalendarFeature
@@ -16,7 +17,11 @@ struct ContentView: View {
 
   init() {
     let repository: any ScheduleRepository = EventKitScheduleRepository()
-    self.calendarViewFactory = CalendarViewFactory(repository: repository)
+    let parser: any ScheduleNaturalLanguageParser = FoundationModelsParser()
+    self.calendarViewFactory = CalendarViewFactory(
+      repository: repository,
+      parser: parser
+    )
   }
 
   var body: some View {
@@ -25,5 +30,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+  ContentView()
 }


### PR DESCRIPTION
## 주요 작업 내용

### Domain Layer: 자연어 파싱 유스케이스 추가
- `ParsedEvent` 엔티티를 추가하고, 파서 인터페이스(`ScheduleNaturalLanguageParser`)를 Domain에 정의했습니다.
- `ParseEventUseCase`를 구현해 자연어 파싱 실행과 `ParsedEvent -> Schedule` 변환 로직을 분리했습니다.
- `CalendarDomainTestSupport`에 `MockScheduleNaturalLanguageParser`를 추가하고 Domain 테스트를 보강했습니다.

### AI Layer: Foundation Models 파서 구현
- `FoundationModelsParser`를 추가해 Foundation Models 기반 파싱을 우선 시도하도록 구현했습니다.
- Foundation Models 사용 불가/실패 시 휴리스틱 파싱으로 폴백하도록 구성했습니다.
- 휴리스틱 파싱 테스트(단순 입력/복합 입력/종일 일정)를 추가했습니다.

### Presentation/App 통합
- `CalendarViewModel`에 자연어 입력, 파싱, 수정, 저장 액션/상태를 추가했습니다.
- `CalendarView`에 자연어 입력 섹션, 파싱 결과 편집 카드, 저장 버튼 UI를 추가했습니다.
- `CalendarViewFactory`, `ContentView`에서 파서 주입 경로를 연결했습니다.
- 파싱 후 저장 시 기존 일정 로딩 흐름과 동일하게 EventKit 저장 후 목록을 갱신합니다.

### 문서 동기화
- `.agents/rules/Architecture.md`에 AI 파싱 흐름/레이어 역할 반영
- `SeukCalendar/Domain/Module.md`, `SeukCalendar/AI/Module.md`, `SeukCalendar/Feature/Module.md` 최신 구조로 갱신

## 참고사항

- Foundation Models 미지원 환경에서는 휴리스틱 파싱이 동작하도록 설계했습니다.
- 테스트 실행 결과
  - `CalendarFeature` 테스트: iOS Simulator(`iPhone 17`)에서 성공
  - `AI`, `CalendarDomain` 스킴: test action 미설정으로 `build` 기준 검증
- 기존 코드에 존재하던 `#warning` 기반 경고(DesignSystem/Navigation)는 이번 변경과 무관합니다.

## 스크린샷

- UI 변경은 있으나 이번 PR에서는 스크린샷을 생략했습니다.
