### PR TITLE
(#5) iCloud 동기화 변경 감지와 자동 새로고침을 적용합니다.

### DIFF
--- a/.agents/memorys/entries/2026-03-03-mainactor-task-capture-cycle.md
+++ b/.agents/memorys/entries/2026-03-03-mainactor-task-capture-cycle.md
@@ -1,0 +1,65 @@
+## 제목(Title)
+- @MainActor ViewModel에서 deinit 격리 오류와 Task 강한 캡처 순환 참조가 발생한 사례
+
+## 날짜(Date)
+- 2026-03-03
+
+## 유형(Type)
+- mistake
+
+## 키워드(Keywords)
+- workflow:review
+- workflow:test
+- action:weak-capture
+- failure:actor-isolation-error
+- failure:retain-cycle
+- target:file:SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift
+- risk:medium
+- verify:calendarfeature-test
+
+## 컨텍스트(Context)
+- 캘린더 동기화 모니터링 Task를 ViewModel 내부에 추가하는 과정에서 `deinit`에서 MainActor 격리 프로퍼티를 직접 참조했고, 동시에 `self`를 강하게 캡처하는 무한 스트림 Task를 `self`가 보관하도록 구현했다.
+
+## 문제 행동(Bad Action)
+- `@MainActor` 클래스의 `deinit`에서 actor-isolated 프로퍼티를 직접 접근했다.
+- `self -> Task -> self` 강한 참조 고리를 만들 수 있는 캡처 패턴을 사용했다.
+
+## 사용자 피드백(User Feedback)
+- 없음 (로컬 빌드/테스트에서 컴파일 오류와 구조적 결함을 직접 확인 후 수정)
+
+## 원인(Root Cause)
+- Swift 6 actor 격리 규칙(`deinit` nonisolated)과 장수명 비동기 Task 캡처 규칙을 구현 전에 체크리스트로 고정하지 않았다.
+
+## 예방 규칙(Prevention Rule)
+- `@MainActor` 타입의 `deinit`에서는 actor-isolated 상태 접근을 직접 수행하지 않는다.
+- 장수명 Task를 프로퍼티로 저장할 때는 Task 클로저가 `self`를 강하게 유지하지 않도록 `weak self` + 외부 의존성 캡처 패턴을 사용한다.
+
+## 사전 점검(Pre-Command Check)
+- `deinit`에서 actor-isolated 프로퍼티를 직접 참조하고 있지 않은가?
+- `self`가 보유하는 Task가 `self`를 다시 강하게 캡처하고 있지 않은가?
+- 무한/장수명 AsyncStream 루프에서 `weak self` 해제 시 루프 종료 조건이 있는가?
+
+## 금지 동작(Do Not Do)
+- `deinit { pendingTask?.cancel() }`처럼 actor 격리 문맥 검증 없이 템플릿 코드를 복붙하지 않는다.
+- `Task { [weak self] in guard let self else { return }; for await ... }` 형태로 초기에 강한 self를 고정하지 않는다.
+
+## 안전 대안(Safe Alternative)
+- `deinit` 정리 로직이 필요하면 actor-safe한 설계를 먼저 정하고(예: 명시적 stop 메서드), 즉시 컴파일 검증한다.
+- `let repository = self.repository`처럼 필요한 의존성만 캡처하고, 루프 내부에서 `guard let self else { break }`로 안전하게 self를 사용한다.
+
+## 검증 단계(Verification Step)
+- `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme CalendarFeature -destination 'platform=iOS Simulator,id=D76E7868-D294-42A9-BA46-DD23BF6C8B9C' test`
+- `git diff -- SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift`
+
+## 적용 범위(Scope)
+- Feature/ViewModel 계층에서 Notification/Stream 관찰 Task를 추가하는 모든 작업
+
+## 심각도(Severity)
+- medium
+
+## 예시(Examples)
+- 나쁜 예(Bad): `changeObservationTask = Task { [weak self] in guard let self else { return }; for await _ in stream { ... } }`
+- 좋은 예(Good): `let streamProvider = dependency; changeObservationTask = Task { [weak self] in for await _ in streamProvider.stream() { guard let self else { break }; ... } }`
+
+## 관련 메모리(Related Memories)
+- `entries/2026-03-03-test-annotation-korean-and-compile-safety.md`

--- a/.agents/memorys/index/MEMORY_INDEX.md
+++ b/.agents/memorys/index/MEMORY_INDEX.md
@@ -6,6 +6,7 @@
 
 | 날짜(Date) | 파일(File) | 제목(Title) | 핵심 키워드(Keywords) |
 |---|---|---|---|
+| 2026-03-03 | `entries/2026-03-03-mainactor-task-capture-cycle.md` | @MainActor ViewModel에서 deinit 격리 오류와 Task 강한 캡처 순환 참조가 발생한 사례 | workflow:review, failure:actor-isolation-error, failure:retain-cycle, action:weak-capture |
 | 2026-03-03 | `entries/2026-03-03-relative-date-assertion-in-tests.md` | 자연어 파싱 테스트에서 절대 날짜 하드코딩 기대값을 사용한 사례 | workflow:test, action:relative-date-assertion, failure:hardcoded-date, verify:dynamic-reference-date |
 | 2026-03-03 | `entries/2026-03-03-foundation-models-flaky-date-location.md` | Foundation Models 출력 변동을 그대로 신뢰해 날짜/장소 테스트가 플레이키해진 사례 | workflow:test, action:normalize-fm-result, failure:flaky-output, verify:repeated-only-testing |
 | 2026-03-03 | `entries/2026-03-03-core-safe-index-regex-capture.md` | 정규식 캡처 배열 인덱스를 직접 접근해 테스트 크래시가 발생한 사례 | workflow:test, action:safe-index, failure:index-out-of-range, verify:ai-test |

--- a/SeukCalendar/Data/CalendarData/CalendarData.swift
+++ b/SeukCalendar/Data/CalendarData/CalendarData.swift
@@ -1,9 +1,0 @@
-//
-//  CalendarData.swift
-//  CalendarData
-//
-//  Created by YoungK on 2/27/26.
-//
-
-import Foundation
-

--- a/SeukCalendar/Data/CalendarData/Repository/EventKitScheduleRepository.swift
+++ b/SeukCalendar/Data/CalendarData/Repository/EventKitScheduleRepository.swift
@@ -39,6 +39,22 @@ public final class EventKitScheduleRepository: ScheduleRepository {
     }
   }
 
+  public func observeScheduleChanges() -> AsyncStream<Void> {
+    AsyncStream { continuation in
+      let token = NotificationCenter.default.addObserver(
+        forName: .EKEventStoreChanged,
+        object: eventStore,
+        queue: nil
+      ) { _ in
+        continuation.yield(())
+      }
+
+      continuation.onTermination = { _ in
+        NotificationCenter.default.removeObserver(token)
+      }
+    }
+  }
+
   public func create(schedule: Schedule) async throws -> Schedule {
     try ensureReadWriteAccess()
 
@@ -130,8 +146,7 @@ private extension EventKitScheduleRepository {
 
   func preferredCalendar(for schedule: Schedule) -> EKCalendar? {
     if let calendarIdentifier = schedule.calendarIdentifier,
-       let specificCalendar = eventStore.calendar(withIdentifier: calendarIdentifier)
-    {
+       let specificCalendar = eventStore.calendar(withIdentifier: calendarIdentifier) {
       return specificCalendar
     }
 

--- a/SeukCalendar/Data/Data.xcodeproj/xcshareddata/xcschemes/CalendarData.xcscheme
+++ b/SeukCalendar/Data/Data.xcodeproj/xcshareddata/xcschemes/CalendarData.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0CC62F514F8D008707E9"
+               BuildableName = "CalendarData.framework"
+               BlueprintName = "CalendarData"
+               ReferencedContainer = "container:Data.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0CCE2F514F8D008707E9"
+               BuildableName = "CalendarDataTests.xctest"
+               BlueprintName = "CalendarDataTests"
+               ReferencedContainer = "container:Data.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B0E0CC62F514F8D008707E9"
+            BuildableName = "CalendarData.framework"
+            BlueprintName = "CalendarData"
+            ReferencedContainer = "container:Data.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SeukCalendar/Data/Data.xcodeproj/xcshareddata/xcschemes/KeyChainData.xcscheme
+++ b/SeukCalendar/Data/Data.xcodeproj/xcshareddata/xcschemes/KeyChainData.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0C962F514EFC008707E9"
+               BuildableName = "KeyChainData.framework"
+               BlueprintName = "KeyChainData"
+               ReferencedContainer = "container:Data.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0C9E2F514EFC008707E9"
+               BuildableName = "KeyChainDataTests.xctest"
+               BlueprintName = "KeyChainDataTests"
+               ReferencedContainer = "container:Data.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B0E0C962F514EFC008707E9"
+            BuildableName = "KeyChainData.framework"
+            BlueprintName = "KeyChainData"
+            ReferencedContainer = "container:Data.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SeukCalendar/Data/Module.md
+++ b/SeukCalendar/Data/Module.md
@@ -46,11 +46,13 @@ CalendarDomain의 Repository 구현.
 
 **Repository**: `CalendarData/Repository/`
 - `EventKitScheduleRepository.swift`: EventKit 권한 요청, 일정 CRUD, EKEvent ↔ Schedule 변환
+  - `observeScheduleChanges()`로 `EKEventStoreChanged` 알림을 AsyncStream으로 전달
 
 **구현 참고**:
 - Repository 구현: `CalendarData/Repository/EventKitScheduleRepository.swift`
 - EventKit 권한 요청: `requestAccess()`
 - iCloud 캘린더 확인: `hasICloudCalendar()`
+- 외부 변경 감지: `observeScheduleChanges()`
 
 ### 3. UserData
 

--- a/SeukCalendar/Domain/CalendarDomain/Repository/ScheduleRepository.swift
+++ b/SeukCalendar/Domain/CalendarDomain/Repository/ScheduleRepository.swift
@@ -48,6 +48,7 @@ public enum ScheduleRepositoryError: SCError, Equatable {
 public protocol ScheduleRepository {
   func requestAccess() async throws -> Bool
   func fetchAuthorizationStatus() -> ScheduleAuthorizationStatus
+  func observeScheduleChanges() -> AsyncStream<Void>
 
   func create(schedule: Schedule) async throws -> Schedule
   func fetchSchedule(id: String) async throws -> Schedule?
@@ -56,4 +57,12 @@ public protocol ScheduleRepository {
   func deleteSchedule(id: String) async throws
 
   func hasICloudCalendar() -> Bool
+}
+
+public extension ScheduleRepository {
+  func observeScheduleChanges() -> AsyncStream<Void> {
+    AsyncStream { continuation in
+      continuation.finish()
+    }
+  }
 }

--- a/SeukCalendar/Domain/CalendarDomainTestSupport/MockScheduleRepository.swift
+++ b/SeukCalendar/Domain/CalendarDomainTestSupport/MockScheduleRepository.swift
@@ -11,7 +11,7 @@ public final class MockScheduleRepository: ScheduleRepository {
       title: "기본 일정",
       date: DateComponents(year: 2026, month: 3, day: 3),
       time: DateComponents(hour: 10, minute: 0),
-      duration: 3_600,
+      duration: 3600,
       location: nil,
       notes: nil,
       isAllDay: false,
@@ -22,10 +22,12 @@ public final class MockScheduleRepository: ScheduleRepository {
   public var deletedScheduleIDs: [String] = []
   public var fetchedScheduleIDs: [String] = []
   public var fetchedRanges: [DateInterval] = []
+  private var changesContinuation: AsyncStream<Void>.Continuation?
 
   public private(set) var requestAccessCallCount = 0
   public private(set) var fetchAuthorizationStatusCallCount = 0
   public private(set) var hasICloudCalendarCallCount = 0
+  public private(set) var observeScheduleChangesCallCount = 0
 
   public init() {}
 
@@ -37,6 +39,16 @@ public final class MockScheduleRepository: ScheduleRepository {
   public func fetchAuthorizationStatus() -> ScheduleAuthorizationStatus {
     fetchAuthorizationStatusCallCount += 1
     return authorizationStatusValue
+  }
+
+  public func observeScheduleChanges() -> AsyncStream<Void> {
+    observeScheduleChangesCallCount += 1
+    return AsyncStream { continuation in
+      self.changesContinuation = continuation
+      continuation.onTermination = { [weak self] _ in
+        self?.changesContinuation = nil
+      }
+    }
   }
 
   public func create(schedule: Schedule) async throws -> Schedule {
@@ -76,5 +88,9 @@ public final class MockScheduleRepository: ScheduleRepository {
   public func hasICloudCalendar() -> Bool {
     hasICloudCalendarCallCount += 1
     return true
+  }
+
+  public func emitScheduleChange() {
+    changesContinuation?.yield(())
   }
 }

--- a/SeukCalendar/Domain/Domain.xcodeproj/xcshareddata/xcschemes/CalendarDomain.xcscheme
+++ b/SeukCalendar/Domain/Domain.xcodeproj/xcshareddata/xcschemes/CalendarDomain.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0B972F514C1E008707E9"
+               BuildableName = "CalendarDomain.framework"
+               BlueprintName = "CalendarDomain"
+               ReferencedContainer = "container:Domain.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B0E0B9F2F514C1E008707E9"
+               BuildableName = "CalendarDomainTests.xctest"
+               BlueprintName = "CalendarDomainTests"
+               ReferencedContainer = "container:Domain.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B0E0B972F514C1E008707E9"
+            BuildableName = "CalendarDomain.framework"
+            BlueprintName = "CalendarDomain"
+            ReferencedContainer = "container:Domain.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SeukCalendar/Domain/Module.md
+++ b/SeukCalendar/Domain/Module.md
@@ -49,6 +49,7 @@ Domain/
 
 **Repository**: `CalendarDomain/Repository/`
 - `ScheduleRepository.swift`: EventKit 기반 저장소와의 계약 인터페이스
+  - 권한/CRUD/`hasICloudCalendar()` + `observeScheduleChanges()`(외부 일정 변경 스트림) 제공
 - `ScheduleNaturalLanguageParser.swift`: AI 파서 구현체와의 계약 인터페이스
 
 **Service**: `CalendarDomain/Service/`

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
@@ -17,6 +17,7 @@ public struct CalendarView: View {
         modePicker
         dateHeader
         permissionDescription
+        syncStatusDescription
 
         Group {
           switch viewModel.viewMode {
@@ -180,6 +181,14 @@ private extension CalendarView {
         viewModel.send(.moveToToday)
       }
       .font(.system(size: 14, weight: .medium))
+
+      Button {
+        viewModel.send(.refreshSchedules)
+      } label: {
+        Image(systemName: "arrow.clockwise")
+          .font(.system(size: 14, weight: .semibold))
+      }
+      .accessibilityLabel("일정 새로고침")
     }
   }
 
@@ -195,6 +204,29 @@ private extension CalendarView {
         .font(.system(size: 13, weight: .regular))
         .foregroundStyle(.red)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  @ViewBuilder
+  var syncStatusDescription: some View {
+    if let syncStatusMessage = viewModel.syncStatusMessage {
+      Text(syncStatusMessage)
+        .font(.system(size: 12, weight: .regular))
+        .foregroundStyle(syncStatusColor)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  var syncStatusColor: Color {
+    switch viewModel.syncStatusTone {
+    case .normal:
+      return .secondary
+    case .warning:
+      return .orange
+    case .success:
+      return .green
+    case .error:
+      return .red
     }
   }
 

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Action.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Action.swift
@@ -3,6 +3,7 @@ import Foundation
 public extension CalendarViewModel {
   enum Action {
     case onAppear
+    case refreshSchedules
     case changeMode(ViewMode)
     case selectDate(Date)
     case movePeriod(Int)

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Model.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel+Model.swift
@@ -35,6 +35,13 @@ public extension CalendarViewModel {
     }
   }
 
+  enum SyncStatusTone: Equatable {
+    case normal
+    case warning
+    case success
+    case error
+  }
+
   struct ParsedEventDraft: Equatable {
     public var title: String
     public var dateString: String

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarViewModel.swift
@@ -12,6 +12,8 @@ public final class CalendarViewModel {
   public private(set) var permissionState: PermissionState = .idle
   public private(set) var isLoading = false
   public private(set) var visibleEvents: [CalendarEvent] = []
+  public private(set) var syncStatusMessage: String?
+  public private(set) var syncStatusTone: SyncStatusTone = .normal
 
   public private(set) var naturalLanguageInput = ""
   public private(set) var parsedEventDraft: ParsedEventDraft?
@@ -26,6 +28,7 @@ public final class CalendarViewModel {
   private let calendar: Calendar
   private var hasLoaded = false
   private var pendingActionTask: Task<Void, Never>?
+  private var changeObservationTask: Task<Void, Never>?
 
   public init(
     selectedDate: Date = Date(),
@@ -109,6 +112,8 @@ private extension CalendarViewModel {
     switch action {
     case .onAppear:
       await loadIfNeeded()
+    case .refreshSchedules:
+      await handleRefreshSchedules()
     case let .changeMode(mode):
       await handleChangeMode(mode)
     case let .selectDate(date):
@@ -178,6 +183,23 @@ private extension CalendarViewModel {
   func handleMoveToToday() async {
     selectedDate = calendar.startOfDay(for: Date())
     await reloadVisibleEvents()
+  }
+
+  func handleRefreshSchedules() async {
+    let isAuthorized = await ensureCalendarPermission()
+    guard isAuthorized else {
+      return
+    }
+
+    syncStatusMessage = "일정을 새로고침하는 중입니다..."
+    syncStatusTone = .normal
+
+    if await reloadVisibleEvents() {
+      applySyncedStatusMessage()
+    } else {
+      syncStatusMessage = "일정을 새로고침하지 못했습니다. 잠시 후 다시 시도해주세요."
+      syncStatusTone = .error
+    }
   }
 
   func handleUpdateNaturalLanguageInput(_ text: String) {
@@ -269,23 +291,33 @@ private extension CalendarViewModel {
       return
     }
 
+    startObservingScheduleChangesIfNeeded()
+
     guard !hasLoaded else {
       return
     }
 
     hasLoaded = true
-    await reloadVisibleEvents()
+    if await reloadVisibleEvents() {
+      applySyncedStatusMessage()
+    }
   }
 
   func ensureCalendarPermission() async -> Bool {
     switch repository.fetchAuthorizationStatus() {
     case .fullAccess:
       permissionState = .granted
+      applyICloudAvailabilityMessageIfNeeded()
       return true
     case .notDetermined:
       do {
         let granted = try await repository.requestAccess()
-        permissionState = granted ? .granted : .denied("캘린더 접근 권한이 필요합니다.")
+        if granted {
+          permissionState = .granted
+          applyICloudAvailabilityMessageIfNeeded()
+        } else {
+          permissionState = .denied("캘린더 접근 권한이 필요합니다.")
+        }
         return granted
       } catch {
         permissionState = .denied("캘린더 권한 요청 중 오류가 발생했습니다.")
@@ -303,9 +335,10 @@ private extension CalendarViewModel {
     }
   }
 
-  func reloadVisibleEvents() async {
+  @discardableResult
+  func reloadVisibleEvents() async -> Bool {
     guard permissionState == .granted else {
-      return
+      return false
     }
 
     isLoading = true
@@ -314,6 +347,7 @@ private extension CalendarViewModel {
     do {
       let schedules = try await repository.fetchSchedules(in: visibleRange())
       visibleEvents = toCalendarEvents(from: schedules)
+      return true
     } catch {
       visibleEvents = []
       if let repositoryError = error as? ScheduleRepositoryError {
@@ -321,7 +355,59 @@ private extension CalendarViewModel {
       } else {
         permissionState = .denied("일정을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.")
       }
+      return false
     }
+  }
+
+  func startObservingScheduleChangesIfNeeded() {
+    guard changeObservationTask == nil else {
+      return
+    }
+
+    syncStatusMessage = "iCloud 변경 사항을 모니터링하고 있습니다."
+    syncStatusTone = .normal
+
+    let repository = self.repository
+    changeObservationTask = Task { [weak self] in
+      for await _ in repository.observeScheduleChanges() {
+        if Task.isCancelled {
+          break
+        }
+        guard let self else {
+          break
+        }
+        await self.handleExternalScheduleChange()
+      }
+    }
+  }
+
+  func handleExternalScheduleChange() async {
+    syncStatusMessage = "iCloud 변경 사항을 반영하는 중입니다..."
+    syncStatusTone = .normal
+
+    if await reloadVisibleEvents() {
+      applySyncedStatusMessage()
+    } else {
+      syncStatusMessage = "변경 사항 동기화에 실패했습니다. 잠시 후 다시 시도해주세요."
+      syncStatusTone = .error
+    }
+  }
+
+  func applyICloudAvailabilityMessageIfNeeded() {
+    guard !repository.hasICloudCalendar() else {
+      return
+    }
+
+    syncStatusMessage = "iCloud 캘린더를 찾지 못해 로컬 일정만 보일 수 있습니다."
+    syncStatusTone = .warning
+  }
+
+  func applySyncedStatusMessage() {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.dateFormat = "a h:mm"
+    syncStatusMessage = "최근 동기화: \(formatter.string(from: Date()))"
+    syncStatusTone = .success
   }
 
   func visibleRange() -> DateInterval {

--- a/SeukCalendar/Feature/CalendarFeatureTests/CalendarFeatureTests.swift
+++ b/SeukCalendar/Feature/CalendarFeatureTests/CalendarFeatureTests.swift
@@ -1,6 +1,7 @@
 import CalendarDomain
 import CalendarDomainTestSupport
 @testable import CalendarFeature
+import DesignSystem
 import Foundation
 import Testing
 
@@ -24,6 +25,30 @@ struct CalendarFeatureTests {
     #expect(viewModel.visibleEvents.count == 1)
     #expect(viewModel.permissionState == .granted)
     #expect(mockRepository.fetchedRanges.count == 1)
+  }
+
+  @Test("refreshSchedules_수동_새로고침시_일정을_다시_로드합니다")
+  @MainActor
+  func refreshSchedules_reloadsVisibleEvents() async {
+    let mockRepository = MockScheduleRepository()
+    mockRepository.authorizationStatusValue = .fullAccess
+    mockRepository.schedulesToReturn = [CalendarFeatureTests.fixtureSchedule(title: "첫 일정")]
+
+    let viewModel = CalendarViewModel(
+      selectedDate: Self.fixedDate,
+      viewMode: .month,
+      calendar: Self.fixedCalendar,
+      repository: mockRepository
+    )
+
+    await viewModel.send(.onAppear).value
+    mockRepository.schedulesToReturn = [CalendarFeatureTests.fixtureSchedule(id: "event-2", title: "갱신 일정")]
+
+    await viewModel.send(.refreshSchedules).value
+
+    #expect(mockRepository.fetchedRanges.count == 2)
+    #expect(viewModel.visibleEvents.first?.title == "갱신 일정")
+    #expect(viewModel.syncStatusMessage?.contains("최근 동기화") == true)
   }
 
   @Test("movePeriod_월_모드에서_한달_이동합니다")
@@ -88,6 +113,31 @@ struct CalendarFeatureTests {
     #expect(viewModel.permissionState == .granted)
     #expect(viewModel.visibleEvents.count == 1)
     #expect(mockRepository.fetchedRanges.count == 1)
+  }
+
+  @Test("onAppear_이벤트스토어_변경시_자동으로_일정을_다시_로드합니다")
+  @MainActor
+  func onAppear_reloadsVisibleEvents_whenEventStoreChanged() async {
+    let mockRepository = MockScheduleRepository()
+    mockRepository.authorizationStatusValue = .fullAccess
+    mockRepository.schedulesToReturn = [CalendarFeatureTests.fixtureSchedule(title: "기존 일정")]
+
+    let viewModel = CalendarViewModel(
+      selectedDate: Self.fixedDate,
+      viewMode: .month,
+      calendar: Self.fixedCalendar,
+      repository: mockRepository
+    )
+
+    await viewModel.send(.onAppear).value
+    mockRepository.schedulesToReturn = [CalendarFeatureTests.fixtureSchedule(id: "event-2", title: "동기화 일정")]
+
+    mockRepository.emitScheduleChange()
+    try? await Task.sleep(for: .milliseconds(50))
+
+    #expect(mockRepository.observeScheduleChangesCallCount == 1)
+    #expect(mockRepository.fetchedRanges.count == 2)
+    #expect(viewModel.visibleEvents.first?.title == "동기화 일정")
   }
 
   @Test("eventsByDay_다일_일정을_각_일자에_포함합니다")
@@ -202,7 +252,7 @@ private extension CalendarFeatureTests {
     return components.date ?? .init(timeIntervalSince1970: 0)
   }
 
-  static func fixtureSchedule() -> Schedule {
+  static func fixtureSchedule(id: String = "event-1", title: String = "테스트 일정") -> Schedule {
     let dayComponents = DateComponents(
       calendar: fixedCalendar,
       timeZone: fixedCalendar.timeZone,
@@ -218,8 +268,8 @@ private extension CalendarFeatureTests {
     )
 
     return Schedule(
-      id: "event-1",
-      title: "테스트 일정",
+      id: id,
+      title: title,
       date: dayComponents,
       time: timeComponents,
       duration: 3600,

--- a/SeukCalendar/Feature/Module.md
+++ b/SeukCalendar/Feature/Module.md
@@ -46,8 +46,9 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 **Calendar**: `CalendarFeature/Calendar/`
 - CalendarView.swift: Calendar View
 - CalendarViewModel.swift: Calendar ViewModel (@Observable)
-- CalendarViewModel+Action.swift: ViewModel Action enum 분리
-- CalendarViewModel+Model.swift: ViewModel 보조 enum/모델(ViewMode/PermissionState/ParsedEventDraft) 분리
+  - 캘린더 로드/권한/자연어 파싱 + iCloud 변경 감지 기반 자동 새로고침 처리
+- CalendarViewModel+Action.swift: ViewModel Action enum 분리 (`refreshSchedules` 포함)
+- CalendarViewModel+Model.swift: ViewModel 보조 enum/모델(ViewMode/PermissionState/ParsedEventDraft/SyncStatusTone) 분리
 - Components/ScheduleDetailView.swift: 일정 상세 화면
 
 **ViewFactory**: `CalendarFeature/CalendarViewFactory.swift`

--- a/SeukCalendar/SeukCalendar.xcworkspace/contents.xcworkspacedata
+++ b/SeukCalendar/SeukCalendar.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,10 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Navigation/Navigation.xcodeproj">
+      location = "group:SeukCalendar.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:DesignSystem/DesignSystem.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Feature/Feature.xcodeproj">
@@ -11,7 +14,10 @@
       location = "group:Domain/Domain.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:DesignSystem/DesignSystem.xcodeproj">
+      location = "group:Data/Data.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AI/AI.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Core/Core.xcodeproj">
@@ -20,12 +26,6 @@
       location = "group:Coordinator/Coordinator.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:AI/AI.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Data/Data.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:SeukCalendar.xcodeproj">
+      location = "group:Navigation/Navigation.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
## 주요 작업 내용

### EventKit 동기화 감지 파이프라인 추가
- `ScheduleRepository`에 `observeScheduleChanges()` 스트림 계약을 추가했습니다.
- `EventKitScheduleRepository`에서 `EKEventStoreChanged` 알림을 `AsyncStream`으로 전달하도록 구현했습니다.
- `MockScheduleRepository`에 변경 알림 emit 훅과 호출 카운트를 추가했습니다.

### CalendarFeature 동기화 UX 개선
- `CalendarViewModel`에서 변경 감지 구독 후 자동 재로딩을 수행하도록 추가했습니다.
- 동기화 상태(`syncStatusMessage`, `syncStatusTone`)를 도입하고 수동 새로고침 액션(`refreshSchedules`)을 추가했습니다.
- `CalendarView`에 동기화 상태 텍스트와 새로고침 버튼을 반영했습니다.

### 테스트/문서/메모리 반영
- `CalendarFeatureTests`에 수동 새로고침/외부 변경 자동 반영 테스트를 추가했습니다.
- `Data/Domain/Feature Module.md`에 동기화 모니터링 관련 설명을 갱신했습니다.
- 재발 방지용 memory를 신규 작성하고 `MEMORY_INDEX.md`를 업데이트했습니다.

## 참고사항

- EventKit/iCloud의 전파 메커니즘을 신뢰하고, 앱은 변경 감지 후 재조회/UI 갱신을 담당합니다.
- 로컬 검증 결과:
  - `CalendarFeature` 스킴 테스트 통과
  - `CalendarDomain` 스킴 빌드 성공
  - `CalendarData` 스킴 빌드 성공
- `CalendarDomain`, `CalendarData`는 test action이 구성되어 있지 않아 `build`로 검증했습니다.

## 스크린샷

- UI 변경은 상태 텍스트/새로고침 버튼 수준이라 스크린샷은 생략했습니다.
