### PR TITLE
(#7) 오늘 일정 WidgetKit 위젯을 구현합니다.

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -32,6 +32,7 @@
 | **Data** | Repository 구현, API Client 작업 | `SeukCalendar/Data/Module.md` |
 | **AI** | AI 작업 | `SeukCalendar/AI/Module.md` |
 | **Feature** | View, ViewModel, ViewFactory 작업 | `SeukCalendar/Feature/Module.md` |
+| **SeukCalendar App** | 앱 진입점/위젯 Extension 작업 | `SeukCalendar/SeukCalendar/Module.md` |
 
 ---
 

--- a/.agents/rules/Architecture.md
+++ b/.agents/rules/Architecture.md
@@ -119,8 +119,11 @@ SeukCalendar/
 │   └── AI.xcodeproj
 ├── Feature/                # UI 레이어 (다중 타겟)
 │   └── Feature.xcodeproj
-└── SeukCalendar/           # App Target
-    └── SeukCalendar.xcodeproj
+├── SeukCalendar/           # App + Widget Extension 타겟
+│   └── SeukCalendar.xcodeproj
+└── TodayScheduleWidget/    # Widget Extension 소스
+    ├── TodayScheduleWidget.swift
+    └── TodayScheduleWidgetBundle.swift
 ```
 
 **핵심 설계 원칙**:
@@ -140,6 +143,8 @@ SeukCalendar/
 | **Data** | Repository 구현, API Client, KeyChain | Core, Domain | [Module.md](SeukCalendar/Data/Module.md) |
 | **AI** | Foundation Models, External API, OCR, Speech | Core, Domain | [Module.md](SeukCalendar/AI/Module.md) |
 | **Feature** | View, ViewModel, ViewFactory | Core, DesignSystem, Domain, Navigation | [Module.md](SeukCalendar/Feature/Module.md) |
+| **SeukCalendar(App)** | 앱 진입점, DI 조립, 위젯 딥링크 처리 | Feature, Data, Domain, AI | [Module.md](SeukCalendar/SeukCalendar/Module.md) |
+| **TodayScheduleWidget** | 홈/잠금화면 일정 위젯, TimelineProvider | App Groups(UserDefaults), WidgetKit | [Module.md](SeukCalendar/SeukCalendar/Module.md) |
 
 **의존성 방향**:
 1. **Core**: 최하위 레이어, 의존성 없음
@@ -149,7 +154,8 @@ SeukCalendar/
 5. **AI**: 해당 Domain + Core에 의존
 6. **Feature**: 필요한 Domain + DesignSystem + Core에 의존
 7. **Coordinator**: Feature + Domain + Navigation에 의존
-8. **App**: 모든 Framework 통합
+8. **App**: 모든 Framework 통합 + Widget 데이터 동기화
+9. **Widget Extension**: App Groups를 통해 공유 스냅샷을 읽고 UI 렌더링
 
 ---
 
@@ -271,6 +277,24 @@ ParsedEvent
 ParseEventUseCase.toSchedule()
     ↓
 CreateScheduleUseCase → ScheduleRepository (EventKit)
+```
+
+### Widget 데이터 공유 흐름
+
+```
+CalendarViewModel
+    ↓ fetch/create/update/delete
+WidgetSyncingScheduleRepository (App)
+    ↓
+EventKitScheduleRepository (Data)
+    ↓
+WidgetScheduleSnapshotStore (App Groups UserDefaults)
+    ↓
+WidgetCenter.reloadTimelines()
+    ↓
+TodayScheduleWidget TimelineProvider
+    ↓
+Small / Medium / Large / Lock Screen 위젯 렌더링
 ```
 
 ---

--- a/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
+++ b/SeukCalendar/Feature/CalendarFeature/Calendar/CalendarView.swift
@@ -4,10 +4,15 @@ import SwiftUI
 public struct CalendarView: View {
   @State private var viewModel: CalendarViewModel
   @State private var path: [CalendarEvent] = []
+  @State private var pendingScheduleID: String?
 
   @MainActor
-  public init(viewModel: CalendarViewModel) {
+  public init(
+    viewModel: CalendarViewModel,
+    initialScheduleID: String? = nil
+  ) {
     _viewModel = State(initialValue: viewModel)
+    _pendingScheduleID = State(initialValue: initialScheduleID)
   }
 
   public var body: some View {
@@ -44,7 +49,11 @@ public struct CalendarView: View {
         }
       }
       .task {
-        viewModel.send(.onAppear)
+        await viewModel.send(.onAppear).value
+        openPendingScheduleIfNeeded()
+      }
+      .onChange(of: viewModel.visibleEvents.map(\.id)) { _, _ in
+        openPendingScheduleIfNeeded()
       }
       .navigationDestination(for: CalendarEvent.self) { event in
         ScheduleDetailView(event: event)
@@ -54,6 +63,22 @@ public struct CalendarView: View {
 }
 
 private extension CalendarView {
+  func openPendingScheduleIfNeeded() {
+    guard let pendingScheduleID else {
+      return
+    }
+
+    let targetDate = viewModel.selectedDate
+    let events = viewModel.events(on: targetDate)
+
+    guard let event = events.first(where: { $0.id == pendingScheduleID }) else {
+      return
+    }
+
+    path = [event]
+    self.pendingScheduleID = nil
+  }
+
   var aiParsingSection: some View {
     VStack(alignment: .leading, spacing: 10) {
       Text("AI 일정 파싱")

--- a/SeukCalendar/Feature/CalendarFeature/CalendarViewFactory.swift
+++ b/SeukCalendar/Feature/CalendarFeature/CalendarViewFactory.swift
@@ -15,7 +15,17 @@ public struct CalendarViewFactory {
   }
 
   @ViewBuilder
-  public func makeCalendarView() -> some View {
-    CalendarView(viewModel: CalendarViewModel(repository: repository, parser: parser))
+  public func makeCalendarView(
+    initialSelectedDate: Date = Date(),
+    initialScheduleID: String? = nil
+  ) -> some View {
+    CalendarView(
+      viewModel: CalendarViewModel(
+        selectedDate: initialSelectedDate,
+        repository: repository,
+        parser: parser
+      ),
+      initialScheduleID: initialScheduleID
+    )
   }
 }

--- a/SeukCalendar/Feature/Module.md
+++ b/SeukCalendar/Feature/Module.md
@@ -54,7 +54,8 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 **ViewFactory**: `CalendarFeature/CalendarViewFactory.swift`
 - 화면 생성 팩토리
 - `CalendarViewModel` 생성/주입 책임 보유 (`CalendarView`는 필수 주입만 허용)
-- DIContainer 도입 전까지 `makeCalendarView()` 내부에서 전달받은 `ScheduleRepository`와 `ScheduleNaturalLanguageParser`로 `CalendarViewModel`을 생성
+- DIContainer 도입 전까지 `makeCalendarView(initialSelectedDate:initialScheduleID:)` 내부에서 전달받은 `ScheduleRepository`와 `ScheduleNaturalLanguageParser`로 `CalendarViewModel`을 생성
+- 위젯 딥링크 진입 시 초기 날짜/일정 ID를 전달받아 상세 화면까지 연결
 
 **구현 참고**:
 - ViewModel: `CalendarFeature/Calendar/CalendarViewModel.swift`
@@ -123,6 +124,7 @@ Feature 관련 유틸리티(모든 Feature가 의존).
 - ViewModel의 공개 상태 구독
 - 자연어 입력 필드 + 파싱 결과 편집 카드 + 저장 버튼 UI 포함
 - 파싱 결과 편집 카드에서 기본 알림 옵션(없음/시작 시간/5·15·30·60분/1일 전) 추가·삭제 지원
+- `initialScheduleID`가 전달된 경우 해당 일정 상세 화면을 자동 오픈
 
 ### ViewFactory
 

--- a/SeukCalendar/SeukCalendar.xcodeproj/project.pbxproj
+++ b/SeukCalendar/SeukCalendar.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		599D701F67B68D6A2979ED76 /* TodayScheduleWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9F9767B9AE1050BD52AA356E /* TodayScheduleWidget.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6CB44CFBAD0D77BE1D2EC84A /* TodayScheduleWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA8277D61385A797079499 /* TodayScheduleWidget.swift */; };
 		7B0E0D622F51513B008707E9 /* AI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D552F51513B008707E9 /* AI.framework */; };
 		7B0E0D632F51513B008707E9 /* AI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D552F51513B008707E9 /* AI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B0E0D642F51513B008707E9 /* Coordinator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D562F51513B008707E9 /* Coordinator.framework */; };
@@ -33,9 +35,32 @@
 		7B0E0D792F51513B008707E9 /* CalendarFeature.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D602F51513B008707E9 /* CalendarFeature.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B0E0D7A2F51513B008707E9 /* Navigation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D612F51513B008707E9 /* Navigation.framework */; };
 		7B0E0D7B2F51513B008707E9 /* Navigation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B0E0D612F51513B008707E9 /* Navigation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7C8F85C05BB6B452C90AB01D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4EFCE6C6A52CF38C214B3AFF /* Assets.xcassets */; };
+		C32511CB4770232E34F6B6B8 /* TodayScheduleWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7E67370CE6319E4CBBD641 /* TodayScheduleWidgetBundle.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		5A684DACF1BD503E4031D83B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7B58BF392DF6800700FF47AB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A9B51C4E55549EAEC040D740;
+			remoteInfo = TodayScheduleWidget;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
+		3CB8A9FB2AB0AF457EF44442 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				599D701F67B68D6A2979ED76 /* TodayScheduleWidget.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7B0E0D7C2F51513B008707E9 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -62,6 +87,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		16BA8277D61385A797079499 /* TodayScheduleWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodayScheduleWidget.swift; sourceTree = "<group>"; };
+		1C7E67370CE6319E4CBBD641 /* TodayScheduleWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TodayScheduleWidgetBundle.swift; sourceTree = "<group>"; };
+		1DB52B69F41757AFC19878F9 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4EFCE6C6A52CF38C214B3AFF /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7B09AD9A2E268FE500327B42 /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B0E0D552F51513B008707E9 /* AI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B0E0D562F51513B008707E9 /* Coordinator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Coordinator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -78,6 +107,8 @@
 		7B0E0D612F51513B008707E9 /* Navigation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Navigation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B2BA8502EB84AD70089B130 /* CoreModule.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CoreModule.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7BD09ABD2F51374F0035BF41 /* SeukCalendar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SeukCalendar.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F9767B9AE1050BD52AA356E /* TodayScheduleWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TodayScheduleWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5313880E952C74761D382B3 /* TodayScheduleWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = TodayScheduleWidget.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -102,6 +133,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0BF9EE7FEB1BF8D0547FA1F0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7BD09ABA2F51374F0035BF41 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -131,6 +169,7 @@
 				7BD09ABE2F51374F0035BF41 /* SeukCalendar */,
 				B0CA1EEA2E228EB500E355E6 /* Frameworks */,
 				B0B31AF72EBF498F00C1F532 /* Recovered References */,
+				952FDDD702E194E9D1A81EBC /* TodayScheduleWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -138,8 +177,21 @@
 			isa = PBXGroup;
 			children = (
 				7BD09ABD2F51374F0035BF41 /* SeukCalendar.app */,
+				9F9767B9AE1050BD52AA356E /* TodayScheduleWidget.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		952FDDD702E194E9D1A81EBC /* TodayScheduleWidget */ = {
+			isa = PBXGroup;
+			children = (
+				C2FF06A454074F664E2A6630 /* Resources */,
+				1C7E67370CE6319E4CBBD641 /* TodayScheduleWidgetBundle.swift */,
+				16BA8277D61385A797079499 /* TodayScheduleWidget.swift */,
+				1DB52B69F41757AFC19878F9 /* Info.plist */,
+				A5313880E952C74761D382B3 /* TodayScheduleWidget.entitlements */,
+			);
+			path = TodayScheduleWidget;
 			sourceTree = "<group>";
 		};
 		B0B31AF72EBF498F00C1F532 /* Recovered References */ = {
@@ -172,6 +224,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		C2FF06A454074F664E2A6630 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				4EFCE6C6A52CF38C214B3AFF /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -183,20 +243,37 @@
 				7BD09ABA2F51374F0035BF41 /* Frameworks */,
 				7BD09ABB2F51374F0035BF41 /* Resources */,
 				7B0E0D7C2F51513B008707E9 /* Embed Frameworks */,
+				3CB8A9FB2AB0AF457EF44442 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				69296AB80459E48FB46DF773 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				7BD09ABE2F51374F0035BF41 /* SeukCalendar */,
 			);
 			name = SeukCalendar;
-			packageProductDependencies = (
-			);
 			productName = SeukCalendar;
 			productReference = 7BD09ABD2F51374F0035BF41 /* SeukCalendar.app */;
 			productType = "com.apple.product-type.application";
+		};
+		A9B51C4E55549EAEC040D740 /* TodayScheduleWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1445D6BE058B74C28EA8A05D /* Build configuration list for PBXNativeTarget "TodayScheduleWidget" */;
+			buildPhases = (
+				76E8590E7649AF11359CDBC3 /* Sources */,
+				0BF9EE7FEB1BF8D0547FA1F0 /* Frameworks */,
+				54B19CAA6315BAAE7872CA5C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TodayScheduleWidget;
+			productName = TodayScheduleWidget;
+			productReference = 9F9767B9AE1050BD52AA356E /* TodayScheduleWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -222,19 +299,26 @@
 			);
 			mainGroup = 7B58BF382DF6800700FF47AB;
 			minimizedProjectReferenceProxies = 1;
-			packageReferences = (
-			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 7B58BF422DF6800700FF47AB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				7BD09ABC2F51374F0035BF41 /* SeukCalendar */,
+				A9B51C4E55549EAEC040D740 /* TodayScheduleWidget */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		54B19CAA6315BAAE7872CA5C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7C8F85C05BB6B452C90AB01D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7BD09ABB2F51374F0035BF41 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -245,6 +329,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		76E8590E7649AF11359CDBC3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C32511CB4770232E34F6B6B8 /* TodayScheduleWidgetBundle.swift in Sources */,
+				6CB44CFBAD0D77BE1D2EC84A /* TodayScheduleWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7BD09AB92F51374F0035BF41 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -254,7 +347,45 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		69296AB80459E48FB46DF773 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TodayScheduleWidget;
+			target = A9B51C4E55549EAEC040D740 /* TodayScheduleWidget */;
+			targetProxy = 5A684DACF1BD503E4031D83B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		69C23AB7522E234EDC410293 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				APP_GROUPS = group.com.youngkyu.SeukCalendar;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = TodayScheduleWidget/TodayScheduleWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MPMHNJMTGA;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TodayScheduleWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "슥캘린더";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.youngkyu.SeukCalendar.TodayScheduleWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		7B58BF4D2DF6800900FF47AB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -377,8 +508,10 @@
 		7BD09AC62F5137500035BF41 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUPS = group.com.youngkyu.SeukCalendar;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SeukCalendar/App/Resources/SeukCalendar.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = MPMHNJMTGA;
@@ -425,8 +558,10 @@
 		7BD09AC72F5137500035BF41 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUPS = group.com.youngkyu.SeukCalendar;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SeukCalendar/App/Resources/SeukCalendar.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = MPMHNJMTGA;
@@ -470,9 +605,48 @@
 			};
 			name = Release;
 		};
+		F0B3916010427C6F04EBCC25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				APP_GROUPS = group.com.youngkyu.SeukCalendar;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = TodayScheduleWidget/TodayScheduleWidget.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = MPMHNJMTGA;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TodayScheduleWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "슥캘린더";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.youngkyu.SeukCalendar.TodayScheduleWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1445D6BE058B74C28EA8A05D /* Build configuration list for PBXNativeTarget "TodayScheduleWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F0B3916010427C6F04EBCC25 /* Release */,
+				69C23AB7522E234EDC410293 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7B58BF3C2DF6800700FF47AB /* Build configuration list for PBXProject "SeukCalendar" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SeukCalendar/SeukCalendar/App/Resources/Info.plist
+++ b/SeukCalendar/SeukCalendar/App/Resources/Info.plist
@@ -32,6 +32,16 @@
 				<string>kakao1271803</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>widget</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>seukcalendar</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>

--- a/SeukCalendar/SeukCalendar/App/Resources/SeukCalendar.entitlements
+++ b/SeukCalendar/SeukCalendar/App/Resources/SeukCalendar.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.youngkyu.SeukCalendar</string>
+	</array>
+</dict>
+</plist>

--- a/SeukCalendar/SeukCalendar/App/Widget/WidgetScheduleSnapshotStore.swift
+++ b/SeukCalendar/SeukCalendar/App/Widget/WidgetScheduleSnapshotStore.swift
@@ -1,0 +1,82 @@
+import CalendarDomain
+import Foundation
+import WidgetKit
+
+struct WidgetScheduleSnapshot: Codable, Sendable {
+  struct Item: Codable, Hashable, Sendable, Identifiable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let isAllDay: Bool
+    let location: String?
+  }
+
+  let generatedAt: Date
+  let items: [Item]
+}
+
+struct WidgetScheduleSnapshotStore {
+  private let userDefaults: UserDefaults?
+  private let encoder: JSONEncoder
+
+  init(appGroupIdentifier: String = WidgetSharedConstants.appGroupIdentifier) {
+    userDefaults = UserDefaults(suiteName: appGroupIdentifier)
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    self.encoder = encoder
+  }
+
+  func save(
+    schedules: [Schedule],
+    generatedAt: Date = Date(),
+    calendar: Calendar = .current
+  ) {
+    let mappedItems: [WidgetScheduleSnapshot.Item] = schedules
+      .compactMap { (schedule: Schedule) -> WidgetScheduleSnapshot.Item? in
+        guard let startDate = schedule.startDate(using: calendar),
+              let endDate = schedule.endDate(using: calendar)
+        else {
+          return nil
+        }
+
+        let fallbackIdentifier = "\(Int(startDate.timeIntervalSince1970))_\(schedule.title)"
+
+        return WidgetScheduleSnapshot.Item(
+          id: schedule.id ?? fallbackIdentifier,
+          title: schedule.title.isEmpty ? "제목 없음" : schedule.title,
+          startDate: startDate,
+          endDate: endDate,
+          isAllDay: schedule.isAllDay,
+          location: schedule.location
+        )
+      }
+      .sorted(by: { (lhs: WidgetScheduleSnapshot.Item, rhs: WidgetScheduleSnapshot.Item) in
+        if lhs.startDate == rhs.startDate {
+          return lhs.title < rhs.title
+        }
+        return lhs.startDate < rhs.startDate
+      })
+
+    let snapshot = WidgetScheduleSnapshot(generatedAt: generatedAt, items: mappedItems)
+    persist(snapshot)
+  }
+
+  func clear() {
+    persist(WidgetScheduleSnapshot(generatedAt: Date(), items: []))
+  }
+}
+
+private extension WidgetScheduleSnapshotStore {
+  func persist(_ snapshot: WidgetScheduleSnapshot) {
+    guard let userDefaults,
+          let encoded = try? encoder.encode(snapshot)
+    else {
+      return
+    }
+
+    userDefaults.set(encoded, forKey: WidgetSharedConstants.snapshotStorageKey)
+    WidgetCenter.shared.reloadTimelines(ofKind: WidgetSharedConstants.widgetKind)
+  }
+}

--- a/SeukCalendar/SeukCalendar/App/Widget/WidgetSharedConstants.swift
+++ b/SeukCalendar/SeukCalendar/App/Widget/WidgetSharedConstants.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+enum WidgetSharedConstants {
+  static let appGroupIdentifier = "group.com.youngkyu.SeukCalendar"
+  static let snapshotStorageKey = "today_schedule_widget_snapshot_v1"
+  static let widgetKind = "TodayScheduleWidget"
+  static let deepLinkScheme = "seukcalendar"
+  static let deepLinkHost = "schedule"
+}
+
+enum WidgetDateFormatter {
+  static let queryDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .current
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+}
+
+struct WidgetScheduleDeepLink {
+  let scheduleID: String?
+  let date: Date
+
+  init?(url: URL) {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          components.scheme?.lowercased() == WidgetSharedConstants.deepLinkScheme,
+          components.host?.lowercased() == WidgetSharedConstants.deepLinkHost
+    else {
+      return nil
+    }
+
+    var queryItems: [String: String] = [:]
+    for item in components.queryItems ?? [] {
+      guard let value = item.value else {
+        continue
+      }
+
+      queryItems[item.name] = value
+    }
+
+    if let dateString = queryItems["date"],
+       let parsedDate = WidgetDateFormatter.queryDateFormatter.date(from: dateString) {
+      date = parsedDate
+    } else {
+      date = Date()
+    }
+
+    scheduleID = queryItems["id"]
+  }
+
+  func selectedDate(using calendar: Calendar = .current) -> Date {
+    calendar.startOfDay(for: date)
+  }
+}

--- a/SeukCalendar/SeukCalendar/App/Widget/WidgetSyncingScheduleRepository.swift
+++ b/SeukCalendar/SeukCalendar/App/Widget/WidgetSyncingScheduleRepository.swift
@@ -1,0 +1,110 @@
+import CalendarDomain
+import Foundation
+
+final class WidgetSyncingScheduleRepository: ScheduleRepository {
+  private let baseRepository: any ScheduleRepository
+  private let snapshotStore: WidgetScheduleSnapshotStore
+  private let calendar: Calendar
+
+  init(
+    base: any ScheduleRepository,
+    snapshotStore: WidgetScheduleSnapshotStore = WidgetScheduleSnapshotStore(),
+    calendar: Calendar = .current
+  ) {
+    baseRepository = base
+    self.snapshotStore = snapshotStore
+    self.calendar = calendar
+  }
+
+  func requestAccess() async throws -> Bool {
+    let granted = try await baseRepository.requestAccess()
+
+    if granted {
+      await syncWidgetSnapshotIfPossible()
+    } else {
+      snapshotStore.clear()
+    }
+
+    return granted
+  }
+
+  func fetchAuthorizationStatus() -> ScheduleAuthorizationStatus {
+    baseRepository.fetchAuthorizationStatus()
+  }
+
+  func hasNotificationPermission() async -> Bool {
+    await baseRepository.hasNotificationPermission()
+  }
+
+  func observeScheduleChanges() -> AsyncStream<Void> {
+    let upstream = baseRepository.observeScheduleChanges()
+
+    return AsyncStream { continuation in
+      let task = Task {
+        for await _ in upstream {
+          await syncWidgetSnapshotIfPossible()
+          continuation.yield(())
+        }
+
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  func create(schedule: Schedule) async throws -> Schedule {
+    let created = try await baseRepository.create(schedule: schedule)
+    await syncWidgetSnapshotIfPossible()
+    return created
+  }
+
+  func fetchSchedule(id: String) async throws -> Schedule? {
+    try await baseRepository.fetchSchedule(id: id)
+  }
+
+  func fetchSchedules(in range: DateInterval) async throws -> [Schedule] {
+    let schedules = try await baseRepository.fetchSchedules(in: range)
+    await syncWidgetSnapshotIfPossible()
+    return schedules
+  }
+
+  func update(schedule: Schedule) async throws -> Schedule {
+    let updated = try await baseRepository.update(schedule: schedule)
+    await syncWidgetSnapshotIfPossible()
+    return updated
+  }
+
+  func deleteSchedule(id: String) async throws {
+    try await baseRepository.deleteSchedule(id: id)
+    await syncWidgetSnapshotIfPossible()
+  }
+
+  func hasICloudCalendar() -> Bool {
+    baseRepository.hasICloudCalendar()
+  }
+}
+
+private extension WidgetSyncingScheduleRepository {
+  func syncWidgetSnapshotIfPossible(referenceDate: Date = Date()) async {
+    guard fetchAuthorizationStatus() == .fullAccess else {
+      snapshotStore.clear()
+      return
+    }
+
+    do {
+      let schedules = try await baseRepository.fetchSchedules(in: widgetRange(referenceDate: referenceDate))
+      snapshotStore.save(schedules: schedules, generatedAt: referenceDate, calendar: calendar)
+    } catch {
+      // 위젯 동기화 실패는 본 앱 흐름을 중단시키지 않습니다.
+    }
+  }
+
+  func widgetRange(referenceDate: Date) -> DateInterval {
+    let start = calendar.startOfDay(for: referenceDate)
+    let end = calendar.date(byAdding: .day, value: 2, to: start) ?? start
+    return DateInterval(start: start, end: end)
+  }
+}

--- a/SeukCalendar/SeukCalendar/ContentView.swift
+++ b/SeukCalendar/SeukCalendar/ContentView.swift
@@ -13,10 +13,13 @@ import SwiftUI
 
 @MainActor
 struct ContentView: View {
+  @State private var widgetRoute = WidgetRoute()
+
   private let calendarViewFactory: CalendarViewFactory
 
   init() {
-    let repository: any ScheduleRepository = EventKitScheduleRepository()
+    let baseRepository: any ScheduleRepository = EventKitScheduleRepository()
+    let repository: any ScheduleRepository = WidgetSyncingScheduleRepository(base: baseRepository)
     let parser: any ScheduleNaturalLanguageParser = FoundationModelsParser()
     self.calendarViewFactory = CalendarViewFactory(
       repository: repository,
@@ -25,10 +28,32 @@ struct ContentView: View {
   }
 
   var body: some View {
-    calendarViewFactory.makeCalendarView()
+    calendarViewFactory
+      .makeCalendarView(
+        initialSelectedDate: widgetRoute.selectedDate,
+        initialScheduleID: widgetRoute.scheduleID
+      )
+      .id(widgetRoute.renderID)
+      .onOpenURL { url in
+        guard let deepLink = WidgetScheduleDeepLink(url: url) else {
+          return
+        }
+
+        widgetRoute = WidgetRoute(
+          selectedDate: deepLink.selectedDate(),
+          scheduleID: deepLink.scheduleID,
+          renderID: UUID()
+        )
+      }
   }
 }
 
 #Preview {
   ContentView()
+}
+
+private struct WidgetRoute {
+  var selectedDate: Date = Date()
+  var scheduleID: String?
+  var renderID: UUID = UUID()
 }

--- a/SeukCalendar/SeukCalendar/Module.md
+++ b/SeukCalendar/SeukCalendar/Module.md
@@ -1,0 +1,77 @@
+# SeukCalendar App Module
+
+앱 실행 진입점과 Widget Extension 연동을 담당하는 모듈입니다.
+
+## 역할
+
+- 앱 진입점(App life cycle) 관리
+- CalendarFeature 화면 생성 및 의존성 조립
+- Widget 딥링크 처리(`seukcalendar://schedule?...`)
+- App Groups 기반 위젯 데이터 동기화
+
+## 디렉토리 구조
+
+```
+SeukCalendar/
+├── SeukCalendar.xcodeproj
+├── SeukCalendar/
+│   ├── SeukCalendarApp.swift
+│   ├── ContentView.swift
+│   └── App/
+│       ├── Resources/
+│       │   ├── Info.plist
+│       │   └── SeukCalendar.entitlements
+│       └── Widget/
+│           ├── WidgetSharedConstants.swift
+│           ├── WidgetScheduleSnapshotStore.swift
+│           └── WidgetSyncingScheduleRepository.swift
+└── TodayScheduleWidget/
+    ├── TodayScheduleWidgetBundle.swift
+    ├── TodayScheduleWidget.swift
+    ├── Info.plist
+    └── TodayScheduleWidget.entitlements
+```
+
+## 타겟 구성
+
+### 1. SeukCalendar (Application)
+
+앱 본체 타겟.
+
+- `ContentView.swift`
+  - `WidgetSyncingScheduleRepository`를 사용해 일정 변경 시 위젯 스냅샷 동기화
+  - `.onOpenURL`로 위젯 딥링크를 받아 초기 날짜/일정으로 진입
+- `App/Widget/WidgetScheduleSnapshotStore.swift`
+  - App Group UserDefaults(`group.com.youngkyu.SeukCalendar`)에 위젯 스냅샷 저장
+  - 저장 직후 `WidgetCenter.reloadTimelines` 호출
+
+### 2. TodayScheduleWidget (Widget Extension)
+
+WidgetKit extension 타겟.
+
+- 지원 패밀리
+  - `systemSmall`, `systemMedium`, `systemLarge`
+  - `accessoryCircular`, `accessoryRectangular`, `accessoryInline`
+- TimelineProvider
+  - App Group UserDefaults에서 스냅샷 로드
+  - 일정 변경 시 앱에서 트리거된 reloadTimelines 반영
+- 딥링크
+  - 일정 row 탭 시 `seukcalendar://schedule?date=yyyy-MM-dd&id=<schedule-id>` 오픈
+
+## 의존성
+
+- App 타겟: AI, CalendarData, CalendarDomain, CalendarFeature
+- Widget 타겟: WidgetKit, SwiftUI, Foundation
+- 공유 저장소: App Groups (`group.com.youngkyu.SeukCalendar`)
+
+## Xcode 프로젝트 설정
+
+**위치**: `SeukCalendar/SeukCalendar.xcodeproj`
+
+**주요 설정**:
+- 타겟
+  - `SeukCalendar` (Application)
+  - `TodayScheduleWidget` (App Extension)
+- App Group Entitlements
+  - `SeukCalendar/App/Resources/SeukCalendar.entitlements`
+  - `TodayScheduleWidget/TodayScheduleWidget.entitlements`

--- a/SeukCalendar/TodayScheduleWidget/Info.plist
+++ b/SeukCalendar/TodayScheduleWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>슥캘린더</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/SeukCalendar/TodayScheduleWidget/Resources/Assets.xcassets/Contents.json
+++ b/SeukCalendar/TodayScheduleWidget/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.entitlements
+++ b/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.youngkyu.SeukCalendar</string>
+	</array>
+</dict>
+</plist>

--- a/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.swift
+++ b/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.swift
@@ -93,6 +93,10 @@ private extension TodayScheduleWidgetEntryView {
     entry.snapshot.nextEvent(after: entry.date)
   }
 
+  var upcomingTodayEvents: [WidgetScheduleSnapshot.Item] {
+    todayEvents.filter { $0.endDate > entry.date }
+  }
+
   var remainingTodayCount: Int {
     entry.snapshot.remainingEventCount(after: entry.date, on: entry.date, calendar: calendar)
   }
@@ -215,6 +219,9 @@ private extension TodayScheduleWidgetEntryView {
           .font(.system(size: 14, weight: .bold))
       }
     }
+    .containerBackground(for: .widget) {
+      Color.clear
+    }
     .widgetLabel {
       Text("남은 일정 \(remainingTodayCount)개")
     }
@@ -222,23 +229,28 @@ private extension TodayScheduleWidgetEntryView {
 
   var rectangularView: some View {
     VStack(alignment: .leading, spacing: 2) {
-      if let nextEvent {
-        Text("다음 일정")
-          .font(.caption2)
-          .foregroundStyle(.secondary)
-        Text(nextEvent.title)
+      if upcomingTodayEvents.isEmpty {
+        Text("- 일정 없음")
           .font(.system(size: 12, weight: .semibold))
           .lineLimit(1)
-        Text(timeText(for: nextEvent))
-          .font(.system(size: 11, weight: .medium))
-          .foregroundStyle(.secondary)
       } else {
-        Text("오늘 일정 없음")
-          .font(.system(size: 12, weight: .semibold))
-        Text("앱에서 일정을 추가해보세요")
-          .font(.system(size: 11, weight: .regular))
-          .foregroundStyle(.secondary)
+        ForEach(upcomingTodayEvents.prefix(2)) { event in
+          Text("- \(event.title) \(timeText(for: event))")
+            .font(.system(size: 12, weight: .semibold))
+            .lineLimit(1)
+            .multilineTextAlignment(.leading)
+        }
+
+        if upcomingTodayEvents.count > 2 {
+          Text("- ...")
+            .font(.system(size: 12, weight: .semibold))
+            .lineLimit(1)
+        }
       }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .containerBackground(for: .widget) {
+      Color.clear
     }
   }
 
@@ -249,6 +261,9 @@ private extension TodayScheduleWidgetEntryView {
       } else {
         Text("오늘 일정 없음")
       }
+    }
+    .containerBackground(for: .widget) {
+      Color.clear
     }
   }
 

--- a/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.swift
+++ b/SeukCalendar/TodayScheduleWidget/TodayScheduleWidget.swift
@@ -1,0 +1,438 @@
+import Foundation
+import SwiftUI
+import WidgetKit
+
+struct TodayScheduleWidget: Widget {
+  static let kind = "TodayScheduleWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: Self.kind, provider: TodayScheduleTimelineProvider()) { entry in
+      TodayScheduleWidgetEntryView(entry: entry)
+        .widgetURL(WidgetDeepLinkBuilder.dayURL(for: entry.date))
+    }
+    .configurationDisplayName("오늘 일정")
+    .description("홈 화면과 잠금 화면에서 오늘의 일정을 빠르게 확인합니다.")
+    .supportedFamilies([
+      .systemSmall,
+      .systemMedium,
+      .systemLarge,
+      .accessoryCircular,
+      .accessoryRectangular,
+      .accessoryInline,
+    ])
+  }
+}
+
+private struct TodayScheduleTimelineProvider: TimelineProvider {
+  func placeholder(in context: Context) -> TodayScheduleEntry {
+    TodayScheduleEntry(
+      date: Date(),
+      snapshot: .placeholder
+    )
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (TodayScheduleEntry) -> Void) {
+    let snapshot = WidgetScheduleSnapshotStore().load() ?? .placeholder
+    completion(TodayScheduleEntry(date: Date(), snapshot: snapshot))
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<TodayScheduleEntry>) -> Void) {
+    let snapshot = WidgetScheduleSnapshotStore().load() ?? .empty
+    let entry = TodayScheduleEntry(date: Date(), snapshot: snapshot)
+    let nextRefresh = Calendar.current.date(byAdding: .minute, value: 15, to: Date()) ?? Date().addingTimeInterval(900)
+    completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+  }
+}
+
+private struct TodayScheduleEntry: TimelineEntry {
+  let date: Date
+  let snapshot: WidgetScheduleSnapshot
+}
+
+private struct TodayScheduleWidgetEntryView: View {
+  @Environment(\.widgetFamily) private var family
+
+  let entry: TodayScheduleEntry
+
+  private let calendar = Calendar.current
+
+  var body: some View {
+    switch family {
+    case .systemSmall:
+      smallView
+    case .systemMedium:
+      mediumView
+    case .systemLarge:
+      largeView
+    case .accessoryCircular:
+      circularView
+    case .accessoryRectangular:
+      rectangularView
+    case .accessoryInline:
+      inlineView
+    @unknown default:
+      mediumView
+    }
+  }
+}
+
+private extension TodayScheduleWidgetEntryView {
+  var todayEvents: [WidgetScheduleSnapshot.Item] {
+    entry.snapshot.events(on: entry.date, calendar: calendar)
+  }
+
+  var tomorrowEvents: [WidgetScheduleSnapshot.Item] {
+    guard let tomorrow = calendar.date(byAdding: .day, value: 1, to: entry.date) else {
+      return []
+    }
+
+    return entry.snapshot.events(on: tomorrow, calendar: calendar)
+  }
+
+  var nextEvent: WidgetScheduleSnapshot.Item? {
+    entry.snapshot.nextEvent(after: entry.date)
+  }
+
+  var remainingTodayCount: Int {
+    entry.snapshot.remainingEventCount(after: entry.date, on: entry.date, calendar: calendar)
+  }
+
+  var smallView: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("오늘 일정")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+
+      if let nextEvent {
+        Text(timeText(for: nextEvent))
+          .font(.system(size: 14, weight: .bold))
+          .foregroundStyle(.blue)
+        Text(nextEvent.title)
+          .font(.system(size: 13, weight: .medium))
+          .lineLimit(3)
+      } else {
+        Spacer(minLength: 0)
+        Text("등록된 일정이 없습니다")
+          .font(.system(size: 13, weight: .medium))
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .containerBackground(.fill.tertiary, for: .widget)
+  }
+
+  var mediumView: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("오늘 일정")
+        .font(.system(size: 14, weight: .semibold))
+
+      if todayEvents.isEmpty {
+        Text("오늘은 예정된 일정이 없습니다")
+          .font(.system(size: 13, weight: .regular))
+          .foregroundStyle(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(todayEvents.prefix(3)) { event in
+            scheduleRow(event)
+          }
+
+          if todayEvents.count > 3 {
+            Text("+\(todayEvents.count - 3)개 더")
+              .font(.system(size: 12, weight: .medium))
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .containerBackground(.fill.tertiary, for: .widget)
+  }
+
+  var largeView: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("오늘 일정")
+        .font(.system(size: 16, weight: .bold))
+
+      if todayEvents.isEmpty {
+        Text("오늘 일정이 없습니다")
+          .font(.system(size: 14, weight: .medium))
+          .foregroundStyle(.secondary)
+      } else {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(todayEvents.prefix(6)) { event in
+            scheduleRow(event)
+          }
+
+          if todayEvents.count > 6 {
+            Text("+\(todayEvents.count - 6)개 더")
+              .font(.system(size: 12, weight: .medium))
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Divider()
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text("내일 미리보기")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(.secondary)
+
+        if let tomorrowNext = tomorrowEvents.first {
+          Link(destination: WidgetDeepLinkBuilder.scheduleURL(for: tomorrowNext)) {
+            HStack(spacing: 6) {
+              Text(timeText(for: tomorrowNext))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.blue)
+              Text(tomorrowNext.title)
+                .font(.system(size: 13, weight: .regular))
+                .lineLimit(1)
+            }
+          }
+          .buttonStyle(.plain)
+        } else {
+          Text("내일 일정이 없습니다")
+            .font(.system(size: 13, weight: .regular))
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .containerBackground(.fill.tertiary, for: .widget)
+  }
+
+  var circularView: some View {
+    ZStack {
+      AccessoryWidgetBackground()
+      VStack(spacing: 2) {
+        Image(systemName: "calendar")
+          .font(.system(size: 12, weight: .semibold))
+        Text("\(remainingTodayCount)")
+          .font(.system(size: 14, weight: .bold))
+      }
+    }
+    .widgetLabel {
+      Text("남은 일정 \(remainingTodayCount)개")
+    }
+  }
+
+  var rectangularView: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      if let nextEvent {
+        Text("다음 일정")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+        Text(nextEvent.title)
+          .font(.system(size: 12, weight: .semibold))
+          .lineLimit(1)
+        Text(timeText(for: nextEvent))
+          .font(.system(size: 11, weight: .medium))
+          .foregroundStyle(.secondary)
+      } else {
+        Text("오늘 일정 없음")
+          .font(.system(size: 12, weight: .semibold))
+        Text("앱에서 일정을 추가해보세요")
+          .font(.system(size: 11, weight: .regular))
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  var inlineView: some View {
+    Group {
+      if let nextEvent {
+        Text("\(timeText(for: nextEvent)) \(nextEvent.title)")
+      } else {
+        Text("오늘 일정 없음")
+      }
+    }
+  }
+
+  func scheduleRow(_ event: WidgetScheduleSnapshot.Item) -> some View {
+    Link(destination: WidgetDeepLinkBuilder.scheduleURL(for: event)) {
+      HStack(alignment: .center, spacing: 8) {
+        Text(timeText(for: event))
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(.blue)
+          .frame(minWidth: 52, alignment: .leading)
+
+        VStack(alignment: .leading, spacing: 2) {
+          Text(event.title)
+            .font(.system(size: 12, weight: .medium))
+            .lineLimit(1)
+
+          if let location = event.location, !location.isEmpty {
+            Text(location)
+              .font(.system(size: 11, weight: .regular))
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+          }
+        }
+
+        Spacer(minLength: 0)
+      }
+    }
+    .buttonStyle(.plain)
+  }
+
+  func timeText(for event: WidgetScheduleSnapshot.Item) -> String {
+    if event.isAllDay {
+      return "종일"
+    }
+
+    return WidgetFormatters.timeFormatter.string(from: event.startDate)
+  }
+}
+
+private enum WidgetDeepLinkBuilder {
+  static func scheduleURL(for event: WidgetScheduleSnapshot.Item) -> URL {
+    url(date: event.startDate, scheduleID: event.id)
+  }
+
+  static func dayURL(for date: Date) -> URL {
+    url(date: date, scheduleID: nil)
+  }
+
+  static func url(date: Date, scheduleID: String?) -> URL {
+    var components = URLComponents()
+    components.scheme = WidgetSharedConstants.deepLinkScheme
+    components.host = WidgetSharedConstants.deepLinkHost
+
+    var queryItems = [
+      URLQueryItem(
+        name: "date",
+        value: WidgetFormatters.queryDateFormatter.string(from: date)
+      )
+    ]
+
+    if let scheduleID {
+      queryItems.append(URLQueryItem(name: "id", value: scheduleID))
+    }
+
+    components.queryItems = queryItems
+    if let url = components.url {
+      return url
+    }
+
+    var fallback = URLComponents()
+    fallback.scheme = WidgetSharedConstants.deepLinkScheme
+    fallback.host = WidgetSharedConstants.deepLinkHost
+    return fallback.url ?? URL(fileURLWithPath: "/")
+  }
+}
+
+private enum WidgetFormatters {
+  static let queryDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = .current
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
+  static let timeFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.timeStyle = .short
+    formatter.dateStyle = .none
+    return formatter
+  }()
+}
+
+private enum WidgetSharedConstants {
+  static let appGroupIdentifier = "group.com.youngkyu.SeukCalendar"
+  static let snapshotStorageKey = "today_schedule_widget_snapshot_v1"
+  static let deepLinkScheme = "seukcalendar"
+  static let deepLinkHost = "schedule"
+}
+
+private struct WidgetScheduleSnapshotStore {
+  private let userDefaults: UserDefaults?
+  private let decoder: JSONDecoder
+
+  init(appGroupIdentifier: String = WidgetSharedConstants.appGroupIdentifier) {
+    userDefaults = UserDefaults(suiteName: appGroupIdentifier)
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    self.decoder = decoder
+  }
+
+  func load() -> WidgetScheduleSnapshot? {
+    guard let userDefaults,
+          let data = userDefaults.data(forKey: WidgetSharedConstants.snapshotStorageKey)
+    else {
+      return nil
+    }
+
+    return try? decoder.decode(WidgetScheduleSnapshot.self, from: data)
+  }
+}
+
+private struct WidgetScheduleSnapshot: Codable {
+  struct Item: Codable, Hashable, Identifiable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let isAllDay: Bool
+    let location: String?
+  }
+
+  let generatedAt: Date
+  let items: [Item]
+
+  static let empty = WidgetScheduleSnapshot(generatedAt: Date(), items: [])
+
+  static let placeholder = WidgetScheduleSnapshot(
+    generatedAt: Date(),
+    items: [
+      Item(
+        id: "placeholder-1",
+        title: "팀 스탠드업",
+        startDate: Date(),
+        endDate: Date().addingTimeInterval(3600),
+        isAllDay: false,
+        location: "회의실 A"
+      )
+    ]
+  )
+
+  func events(on date: Date, calendar: Calendar = .current) -> [Item] {
+    let dayStart = calendar.startOfDay(for: date)
+    let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+
+    return items
+      .filter { item in
+        item.startDate < dayEnd && item.endDate > dayStart
+      }
+      .sorted(by: { lhs, rhs in
+        if lhs.startDate == rhs.startDate {
+          return lhs.title < rhs.title
+        }
+        return lhs.startDate < rhs.startDate
+      })
+  }
+
+  func nextEvent(after referenceDate: Date) -> Item? {
+    items
+      .filter { $0.endDate > referenceDate }
+      .sorted(by: { $0.startDate < $1.startDate })
+      .first
+  }
+
+  func remainingEventCount(
+    after referenceDate: Date,
+    on date: Date,
+    calendar: Calendar = .current
+  ) -> Int {
+    events(on: date, calendar: calendar)
+      .filter { $0.endDate > referenceDate }
+      .count
+  }
+}

--- a/SeukCalendar/TodayScheduleWidget/TodayScheduleWidgetBundle.swift
+++ b/SeukCalendar/TodayScheduleWidget/TodayScheduleWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct TodayScheduleWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    TodayScheduleWidget()
+  }
+}


### PR DESCRIPTION
## 주요 작업 내용

### TodayScheduleWidget Extension을 추가합니다.
- `TodayScheduleWidget` 타겟/번들/엔트리/타임라인을 구성했습니다.
- 홈 화면(`systemSmall/Medium/Large`)과 잠금 화면(`accessoryCircular/Rectangular/Inline`) 패밀리를 지원합니다.
- 일정이 없을 때의 빈 상태 메시지와 내일 미리보기 UI를 포함했습니다.

### 앱-위젯 데이터 공유 및 자동 갱신을 구현합니다.
- App Group `group.com.youngkyu.SeukCalendar`를 앱/위젯 양쪽에 설정했습니다.
- `WidgetSyncingScheduleRepository`를 도입해 일정 생성/수정/삭제/변경 관찰 시 위젯 스냅샷을 동기화하도록 구성했습니다.
- 스냅샷 저장 시 `WidgetCenter.reloadTimelines`로 위젯 타임라인을 갱신합니다.

### 위젯 딥링크 진입을 지원합니다.
- URL Scheme `seukcalendar://schedule?date=yyyy-MM-dd&id=<schedule-id>`를 추가했습니다.
- 앱 `ContentView`에서 `.onOpenURL`로 딥링크를 처리합니다.
- `CalendarViewFactory`/`CalendarView`를 확장해 초기 날짜 및 일정 ID 전달 시 상세 화면 자동 진입을 지원합니다.

### 잠금 화면 위젯 표시를 보완합니다.
- `accessoryCircular/Rectangular/Inline`에 `containerBackground(for: .widget)`를 적용해 잠금 화면 경고 메시지가 표시되지 않도록 수정했습니다.
- `accessoryRectangular`를 좌측 정렬 목록형 UI(`- 제목 시간`)로 변경하고, 타이틀 문구를 제거했습니다.
- `accessoryRectangular`는 오늘 일정 중 아직 끝나지 않은 일정만 표시하도록 필터를 조정했습니다.

### 아키텍처/모듈 문서를 동기화합니다.
- `.agents/rules/Architecture.md`
- `.agents/INDEX.md`
- `SeukCalendar/Feature/Module.md`
- `SeukCalendar/SeukCalendar/Module.md` (신규)

### 빌드 검증을 완료했습니다.
- `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme SeukCalendar -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme TodayScheduleWidget -destination 'generic/platform=iOS Simulator' build`

## 참고사항

- 위젯은 App Group UserDefaults 스냅샷을 읽기 때문에, 앱 실행 후 일정 동기화가 한 번 발생해야 최신 상태가 반영됩니다.
- 위젯 행/카드 탭 시 일정 ID 기준으로 앱 상세 화면 진입을 시도하며, 해당 날짜 목록에서 일치 일정을 찾지 못하면 날짜 화면만 열립니다.

## 스크린샷

- UI 시뮬레이터 스크린샷은 본 PR에 포함하지 않았습니다.
