### PR TITLE
(#52) 펜슬 컬러 변수를 디자인시스템 전체 계층으로 동기화합니다.

### DIFF
--- a/.agents/memorys/entries/2026-03-05-pencil-full-color-family-sync.md
+++ b/.agents/memorys/entries/2026-03-05-pencil-full-color-family-sync.md
@@ -1,0 +1,62 @@
+## 제목(Title)
+- 펜슬 컬러 토큰 작업에서 캘린더 일부만 반영해 전체 디자인 시스템 컬러 계층 동기화를 놓칠 뻔한 사례
+
+## 날짜(Date)
+- 2026-03-05
+
+## 유형(Type)
+- rejection
+
+## 키워드(Keywords)
+- workflow:issue-to-pr
+- workflow:design-token
+- action:pencil-color-family-sync
+- failure:partial-color-registration
+- target:file:Pencil/Design.pen
+- verify:color-designsystem-full-coverage
+
+## 컨텍스트(Context)
+- 캘린더 칩 컬러를 변수화하는 작업을 진행하던 중, 사용자로부터 "칩만이 아니라 Primitives/Core 등 전체를 등록해야 한다"는 교정을 받았습니다.
+
+## 문제 행동(Bad Action)
+- 이슈의 예시(칩 색상)에 집중해 컬러 변수 등록 범위를 캘린더 일부로 축소 해석했습니다.
+
+## 사용자 피드백(User Feedback)
+- 사용자 교정: `캘린더 칩에 사용된 컬러만 등록하는게 아니라, Primitives, Core 등 모든 디자인시스템 컬러를 다 등록해야 하는거 알지? Color+DesignSystem.swift 파일에 등록되어 있는 것처럼 말이야.`
+
+## 원인(Root Cause)
+- 디자인 시스템 동기화 작업에서 "부분 수정"을 먼저 적용하고, 기준 파일(`Color+DesignSystem.swift`)의 전체 범위 대조를 선행하지 않았습니다.
+
+## 예방 규칙(Prevention Rule)
+- 펜슬 컬러 토큰 작업 시작 시 `Color+DesignSystem.swift`의 컬러 계층(Primitives/Core/Semantic/SemanticExtensions/Calendar)을 체크리스트로 먼저 고정합니다.
+- 특정 컴포넌트 이슈(예: 칩 컬러)도 항상 전체 계층 누락 여부를 함께 검증합니다.
+
+## 사전 점검(Pre-Command Check)
+- 이번 변경이 특정 컴포넌트 수정인가, 디자인 시스템 전역 동기화인가?
+- `Color+DesignSystem.swift`의 전체 컬러 계층 개수와 `Design.pen` 변수 개수를 대조했는가?
+- 신규/변경 토큰이 어느 계층(Primitives/Core/Semantic/SemanticExtensions/Calendar)에 속하는지 분류했는가?
+
+## 금지 동작(Do Not Do)
+- 컴포넌트 예시 컬러만 반영하고 전체 컬러 계층 동기화를 생략하지 않습니다.
+
+## 안전 대안(Safe Alternative)
+- 코드 기준 토큰 목록을 먼저 추출하고, 그 목록을 기준으로 펜슬 변수 등록/검증을 일괄 수행합니다.
+
+## 검증 단계(Verification Step)
+- `rg -n 'public static let ' SeukCalendar/DesignSystem/DesignSystem/ResourceSystem/ColorSystem/Color+DesignSystem.swift`
+- `jq -r '.variables | keys[]' Pencil/Design.pen | rg '^(Primitives|Core|Semantic|SemanticExtensions|Calendar)\.'`
+- 토큰명/값 대조 스크립트로 누락·불일치 0건 확인
+
+## 적용 범위(Scope)
+- Pencil 기반 컬러 토큰 등록/동기화 작업 전반
+
+## 심각도(Severity)
+- medium
+
+## 예시(Examples)
+- 나쁜 예(Bad): `calendar-chip-*`만 등록하고 `Core/Semantic` 누락
+- 좋은 예(Good): `Color+DesignSystem.swift` 전체 계층 추출 -> `Design.pen` 변수 1:1 등록 -> 자동 대조
+
+## 관련 메모리(Related Memories)
+- `entries/2026-03-05-design-token-source-priority.md`
+- `entries/2026-03-05-font-token-naming-from-pencil.md`

--- a/.agents/memorys/index/MEMORY_INDEX.md
+++ b/.agents/memorys/index/MEMORY_INDEX.md
@@ -6,6 +6,7 @@
 
 | 날짜(Date) | 파일(File) | 제목(Title) | 핵심 키워드(Keywords) |
 |---|---|---|---|
+| 2026-03-05 | `entries/2026-03-05-pencil-full-color-family-sync.md` | 펜슬 컬러 토큰 작업에서 캘린더 일부만 반영해 전체 디자인 시스템 컬러 계층 동기화를 놓칠 뻔한 사례 | workflow:issue-to-pr, workflow:design-token, action:pencil-color-family-sync, failure:partial-color-registration, verify:color-designsystem-full-coverage |
 | 2026-03-05 | `entries/2026-03-05-issue-template-mismatch-gh-cli.md` | `gh issue create --body-file` 사용 시 Issue Form 템플릿 구조를 반영하지 않아 이슈 본문 형식이 어긋난 사례 | workflow:issue-to-pr, action:gh-issue-create, failure:template-mismatch, verify:issue-template-sections |
 | 2026-03-05 | `entries/2026-03-05-font-token-naming-from-pencil.md` | 폰트 토큰 작업에서 예시 네이밍(Heading1/Body1)을 유지해 펜슬 네이밍 기준을 놓친 사례 | workflow:issue-to-pr, workflow:design-token, action:font-token-rename, failure:example-font-naming, verify:line-height-ratio-rounding |
 | 2026-03-05 | `entries/2026-03-05-design-token-source-priority.md` | 디자인 토큰 작업에서 기존 예시 컬러를 기준으로 해석해 사용자 의도(펜슬 우선)를 놓칠 뻔한 사례 | workflow:issue-to-pr, workflow:design-token, action:token-source-priority, failure:example-token-assumption, verify:pencil-variable-first |

--- a/Design-Spec.md
+++ b/Design-Spec.md
@@ -40,6 +40,8 @@
 
 ### 1-2. 컬러 토큰 (Color Tokens)
 
+> 관리 원칙: `Pencil/Design.pen` 변수는 `Color+DesignSystem.swift`의 계층(`Primitives/Core/Semantic/SemanticExtensions/Calendar`)과 1:1로 등록/유지합니다.
+
 #### 그레이스케일 예시
 
 | 토큰명 | Light Mode | Dark Mode | 용도 |
@@ -91,10 +93,25 @@
 | `calendar-purple` | #8B5CF6 | #A78BFA | 학습 |
 | `calendar-pink` | #EC4899 | #F472B6 | 기념일 |
 
+#### 캘린더 일정 바/칩 토큰
+
+| 토큰명 | Light Mode | Dark Mode | 용도 |
+|--------|-----------|-----------|------|
+| `calendar-chip-green-bg` | #DFF3E8 | #DFF3E8 | 일정 바(운동/건강) 배경 |
+| `calendar-chip-green-fg` | #2F6A55 | #2F6A55 | 일정 바(운동/건강) 텍스트/스트립 |
+| `calendar-chip-blue-bg` | #DCEEFF | #DCEEFF | 일정 바(업무) 배경 |
+| `calendar-chip-blue-bg-soft` | #E9F5FF | #E9F5FF | 일정 바(업무) 보조 배경 |
+| `calendar-chip-blue-fg` | #2E5F9E | #2E5F9E | 일정 바(업무) 텍스트/스트립 |
+| `calendar-chip-orange-bg` | #FFEED5 | #FFEED5 | 일정 바(약속) 배경 |
+| `calendar-chip-orange-fg` | #9A6228 | #9A6228 | 일정 바(약속) 텍스트/스트립 |
+| `calendar-chip-pink-bg` | #FFE0E4 | #FFE0E4 | 일정 바(기념일/휴일) 배경 |
+| `calendar-chip-pink-fg` | #A33A4B | #A33A4B | 일정 바(기념일/휴일) 텍스트/스트립 |
+
 ### 1-3. 타이포그래피 (Typography)
 
 #### 폰트 패밀리
-- Pretendard
+- 기본 폰트 변수: `font-family-primary`, `font-family-secondary`
+- 현재 기본값: `Pretendard`
 
 #### 폰트 토큰 예시
 


### PR DESCRIPTION
## 주요 작업 내용

### Pencil 컬러 토큰 전수 동기화
- `Color+DesignSystem.swift` 기준으로 `Primitives/Core/Semantic/SemanticExtensions/Calendar` 전체 컬러(총 169개)를 `Pencil/Design.pen` 변수로 등록했습니다.
- 코드 토큰과 펜슬 변수 간 값 대조 스크립트로 누락/불일치 0건을 확인했습니다.

### 홈 캘린더 컴포넌트 컬러 변수화
- 홈 캘린더 컴포넌트(`aObJ1`)의 직접 HEX `fill`/`stroke.fill`을 제거하고 변수 참조로 치환했습니다.
- 캘린더 칩 컬러(`calendar-chip-*`)와 중간 글래스 배경(`glass-bg-medium`) 토큰을 추가해 재사용 가능하게 정리했습니다.

### 문서/메모리 정리
- `Design-Spec.md`에 컬러 관리 원칙(코드 계층과 1:1 동기화)과 캘린더 칩 토큰 표를 반영했습니다.
- 사용자 교정 사항을 memory로 기록하고 `MEMORY_INDEX.md`를 업데이트했습니다.

## 참고사항

- 검증
  - `jq empty Pencil/Design.pen`
  - 토큰 대조 스크립트 결과: `expected=169 actual=169 / missing=0 mismatch=0`
  - `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme DesignSystem -destination 'generic/platform=iOS' build` 성공
- 현재 작업은 Pencil 변수 동기화와 문서/메모리 업데이트 중심이며, Swift 소스 변경은 없습니다.

## 스크린샷

- UI 스크린샷 변경 없음 (디자인 토큰/문서 중심 변경)
