### PR TITLE
(#56) 디자인시스템 컴포넌트 생성 규칙을 추가합니다.

### DIFF
--- a/.agents/INDEX.md
+++ b/.agents/INDEX.md
@@ -46,6 +46,7 @@
 | **코드 리뷰 컨벤션** | 코드 리뷰 | `.agents/rules/code-review-convention.md` |
 | **ViewModel 컨벤션** | ViewModel 파일 구조/DI 규칙 확인 | `.agents/rules/viewmodel-convention.md` |
 | **디자인 가이드** | 디자인 수정/컴포넌트 계층(Tier) 규칙 확인 | `.agents/rules/design-guide.md` |
+| **디자인시스템 컴포넌트 컨벤션** | 디자인시스템 컴포넌트 생성/API 규칙 확인 | `.agents/rules/design-system-component-convention.md` |
 
 ---
 

--- a/.agents/memorys/entries/2026-03-06-explicit-skill-path-priority.md
+++ b/.agents/memorys/entries/2026-03-06-explicit-skill-path-priority.md
@@ -1,0 +1,61 @@
+## 제목(Title)
+- 사용자가 스킬 경로나 이름을 직접 제공한 경우 즉시 해당 스킬을 우선 확인해야 하는 사례
+
+## 날짜(Date)
+- 2026-03-06
+
+## 유형(Type)
+- mistake
+
+## 키워드(Keywords)
+- workflow:skill
+- workflow:issue-to-pr
+- action:read-explicit-skill-path
+- failure:ignored-user-provided-skill
+- target:file:.agents/skills/create-rule/SKILL.md
+- risk:medium
+- verify:explicit-skill-open-first
+
+## 컨텍스트(Context)
+- 사용자가 `create Rule`을 요청했고, 이후 `/.agents/skills/create-rule` 경로를 직접 언급하며 해당 스킬을 확인했는지 물었습니다.
+
+## 문제 행동(Bad Action)
+- `Available skills` 목록에 보이지 않는다는 이유로 사용자가 직접 제공한 스킬 경로를 즉시 확인하지 않았습니다.
+
+## 사용자 피드백(User Feedback)
+- 사용자가 "이 스킬을 확인한거야?"라고 물으며, 지정한 스킬 파일을 실제로 읽었는지 확인을 요청했습니다.
+
+## 원인(Root Cause)
+- 자동 매칭 가능한 스킬 목록을 우선시하면서, 사용자가 명시적으로 지정한 파일 경로/스킬명을 별도 우선순위로 처리하지 않았습니다.
+
+## 예방 규칙(Prevention Rule)
+- 사용자가 스킬 이름이나 스킬 파일 경로를 직접 제공하면 `Available skills` 목록과 무관하게 해당 `SKILL.md`를 먼저 열어 확인합니다.
+- 자동 매칭 목록에 없더라도 사용자가 지정한 경로가 유효하면 그 스킬 절차를 현재 턴에 적용합니다.
+
+## 사전 점검(Pre-Command Check)
+- 사용자가 스킬 이름 또는 스킬 파일 경로를 직접 제공했는가?
+- 제공된 경로에 `SKILL.md`가 실제로 존재하는가?
+- 자동 매칭 목록에 없더라도 사용자 지시 우선으로 읽었는가?
+
+## 금지 동작(Do Not Do)
+- 사용자가 직접 지정한 스킬을 확인하지 않은 상태에서 스킬 기준을 반영했다고 가정하지 않습니다.
+
+## 안전 대안(Safe Alternative)
+- 먼저 지정된 스킬 파일을 열고, 적용 가능한 단계만 요약한 뒤 작업을 이어갑니다.
+
+## 검증 단계(Verification Step)
+- `ls -la <사용자가 제공한 스킬 디렉토리>`
+- `sed -n '1,260p' <사용자가 제공한 스킬 경로>/SKILL.md`
+
+## 적용 범위(Scope)
+- 사용자가 스킬 이름, 슬래시 커맨드, 절대 경로를 직접 지정하는 모든 작업
+
+## 심각도(Severity)
+- medium
+
+## 예시(Examples)
+- 나쁜 예(Bad): 목록에 없다는 이유로 사용자 제공 스킬 경로를 읽지 않고 일반 흐름으로 응답
+- 좋은 예(Good): 사용자 제공 스킬 경로 확인 -> `SKILL.md` 읽기 -> 해당 스킬 절차를 현재 작업에 반영
+
+## 관련 메모리(Related Memories)
+- `entries/2026-03-03-skill-sync-claude-agents.md`

--- a/.agents/memorys/index/MEMORY_INDEX.md
+++ b/.agents/memorys/index/MEMORY_INDEX.md
@@ -6,6 +6,7 @@
 
 | 날짜(Date) | 파일(File) | 제목(Title) | 핵심 키워드(Keywords) |
 |---|---|---|---|
+| 2026-03-06 | `entries/2026-03-06-explicit-skill-path-priority.md` | 사용자가 스킬 경로나 이름을 직접 제공한 경우 즉시 해당 스킬을 우선 확인해야 하는 사례 | workflow:skill, workflow:issue-to-pr, action:read-explicit-skill-path, failure:ignored-user-provided-skill, verify:explicit-skill-open-first |
 | 2026-03-05 | `entries/2026-03-05-pencil-full-color-family-sync.md` | 펜슬 컬러 토큰 작업에서 캘린더 일부만 반영해 전체 디자인 시스템 컬러 계층 동기화를 놓칠 뻔한 사례 | workflow:issue-to-pr, workflow:design-token, action:pencil-color-family-sync, failure:partial-color-registration, verify:color-designsystem-full-coverage |
 | 2026-03-05 | `entries/2026-03-05-issue-template-mismatch-gh-cli.md` | `gh issue create --body-file` 사용 시 Issue Form 템플릿 구조를 반영하지 않아 이슈 본문 형식이 어긋난 사례 | workflow:issue-to-pr, action:gh-issue-create, failure:template-mismatch, verify:issue-template-sections |
 | 2026-03-05 | `entries/2026-03-05-font-token-naming-from-pencil.md` | 폰트 토큰 작업에서 예시 네이밍(Heading1/Body1)을 유지해 펜슬 네이밍 기준을 놓친 사례 | workflow:issue-to-pr, workflow:design-token, action:font-token-rename, failure:example-font-naming, verify:line-height-ratio-rounding |

--- a/.agents/rules/design-system-component-convention.md
+++ b/.agents/rules/design-system-component-convention.md
@@ -8,9 +8,7 @@
 
 ## 적용 범위
 
-- `SeukCalendar/DesignSystem`에 추가되는 신규 컴포넌트
-- 기존 디자인시스템 컴포넌트의 public API를 개편하는 작업
-- `Tier1`, `Tier2`, `Tier3` 및 캘린더 계열 공용 컴포넌트
+- `SeukCalendar/DesignSystem`에 추가되는 신규 컴포넌트 및 기존 컴포넌트
 
 ## 규칙
 

--- a/.agents/rules/design-system-component-convention.md
+++ b/.agents/rules/design-system-component-convention.md
@@ -1,0 +1,180 @@
+# 디자인시스템 컴포넌트 생성 규칙
+
+## 목적
+
+- 디자인시스템 컴포넌트의 public API를 일관된 형태로 유지합니다.
+- UI 구성 정보와 사용자 이벤트 전달 경로를 분리합니다.
+- Preview, 테스트, 상위 뷰 조합 시 재사용성을 높입니다.
+
+## 적용 범위
+
+- `SeukCalendar/DesignSystem`에 추가되는 신규 컴포넌트
+- 기존 디자인시스템 컴포넌트의 public API를 개편하는 작업
+- `Tier1`, `Tier2`, `Tier3` 및 캘린더 계열 공용 컴포넌트
+
+## 규칙
+
+### 1. 생성자 시그니처를 통일합니다
+
+- 모든 public 컴포넌트는 생성자에서 `Configuration`을 필수로 받습니다.
+- 상위 뷰 이벤트 전달이 필요한 경우 `eventListener`를 옵셔널로 받습니다.
+- 개별 파라미터 나열 방식(`title`, `mode`, `onTap` 등)은 지양합니다.
+
+권장 형태:
+
+```swift
+public init(
+  configuration: Configuration,
+  eventListener: EventListener? = nil
+)
+```
+
+### 2. `Configuration`은 UI 정보만 포함합니다
+
+- `Configuration`은 `struct`로 선언합니다.
+- 컴포넌트 외형과 표현 상태를 결정하는 값만 담습니다.
+- 예: `title`, `subtitle`, `icon`, `mode`, `size`, `isSelected`, `badgeCount`
+- 비즈니스 로직, Repository, UseCase, ViewModel, side effect는 포함하지 않습니다.
+- 액션 클로저는 `Configuration`에 넣지 않습니다.
+
+### 3. `EventListener`는 상위 뷰 전달 전용으로 사용합니다
+
+- `EventListener`는 이벤트를 상위 뷰로 전달하는 역할만 가집니다.
+- 내부 상태 저장, 비동기 스트림 관리, 외부 의존성 보관 책임을 두지 않습니다.
+- 이벤트는 컴포넌트 내부에서 발생한 UI 상호작용이나 상태 변화만 표현합니다.
+- 예: `tap`, `longPress`, `didSelectDate(Date)`, `didTapAccessory`
+
+### 4. `eventListener`는 closure typealias를 기본으로 사용합니다
+
+- 기본 권장 타입은 `typealias EventListener = (Event) -> Void` 입니다.
+- 이유:
+  - 상위 뷰에서 `eventListener: { event in ... }` 형태로 바로 주입할 수 있습니다.
+  - 이벤트가 추가되어도 생성자 시그니처는 안정적으로 유지됩니다.
+  - `switch event` 패턴 매칭으로 이벤트 분기를 한 곳에서 처리하기 쉽습니다.
+- 특별한 수명주기 관리나 내부 상태 저장이 없다면 `struct` wrapper나 `class` listener는 기본값으로 사용하지 않습니다.
+
+### 5. 이벤트 방출 방식은 `Event enum + typed closure`를 기본값으로 사용합니다
+
+- 디자인시스템 public API에서는 `Closure` 기반 이벤트 방출을 기본으로 사용합니다.
+- 권장 방식은 단일 이벤트 sink + `Event` enum 조합입니다.
+
+권장 형태:
+
+```swift
+public extension DSChip {
+  enum Event {
+    case tap
+    case removeTap
+  }
+
+  typealias EventListener = (Event) -> Void
+}
+```
+
+### 6. 이벤트는 타입 안전하게 정의합니다
+
+- 여러 이벤트가 존재하면 개별 클로저 여러 개보다 `Event` enum 하나로 묶는 것을 우선합니다.
+- 이벤트 payload는 해당 상호작용에 필요한 최소 정보만 포함합니다.
+- 도메인 객체 전체를 넘기기보다 상위 뷰에 필요한 식별자나 선택 결과를 우선 검토합니다.
+
+### 7. 파일 구조는 역할 기준으로 분리합니다
+
+- 디자인시스템 컴포넌트는 디렉토리 단위로 구성합니다.
+- 기본 경로는 `TierN/<Name>Component/` 형태를 사용합니다.
+- 기본 구현 파일은 항상 `<Name>Component.swift`로 분리합니다.
+- 설정 타입은 항상 `<Name>Component+Configuration.swift`로 분리합니다.
+- 이벤트 타입은 항상 `<Name>Component+Event.swift`로 분리합니다.
+- 계산 로직이 많거나 복잡하면 `<Name>Component+Calculate.swift`를 추가로 분리합니다.
+- 하위 뷰는 `TierN/<Name>Component/Components/` 디렉토리 아래에 둡니다.
+
+권장 구조:
+
+```text
+Tier1/
+└── AComponent/
+    ├── AComponent.swift
+    ├── AComponent+Configuration.swift
+    ├── AComponent+Event.swift
+    ├── AComponent+Calculate.swift
+    └── Components/
+        ├── AComponentHeader.swift
+        └── AComponentRow.swift
+```
+
+## 예시
+
+좋은 예:
+
+```swift
+public struct AComponent: View {
+  private let configuration: Configuration
+  private let eventListener: EventListener?
+
+  public init(
+    configuration: Configuration,
+    eventListener: EventListener? = nil
+  ) {
+    self.configuration = configuration
+    self.eventListener = eventListener
+  }
+
+  public var body: some View {
+    Button(configuration.title) {
+      eventListener?(.tap)
+    }
+  }
+}
+
+public extension AComponent {
+  struct Configuration {
+    let title: String
+    let mode: Mode
+  }
+
+  enum Mode {
+    case normal
+    case selected
+    case disabled
+  }
+
+  enum Event {
+    case tap
+  }
+
+  typealias EventListener = (Event) -> Void
+}
+```
+
+나쁜 예:
+
+```swift
+public init(
+  title: String,
+  isSelected: Bool,
+  mode: String,
+  onTap: @escaping () -> Void,
+  onLongPress: @escaping () -> Void
+)
+```
+
+문제:
+
+- 생성자 파라미터가 늘어날수록 API가 빠르게 불안정해집니다.
+- UI 설정 값과 이벤트 전달 경로가 섞여 역할이 흐려집니다.
+- 이벤트가 늘어날 때 시그니처 변경 범위가 커집니다.
+
+## 체크리스트
+
+- [ ] 생성자가 `configuration`을 필수로 받는가
+- [ ] `eventListener`가 필요한 경우에만 옵셔널로 노출되는가
+- [ ] `Configuration`이 UI 정보만 담고 있는가
+- [ ] `Configuration`에 액션 클로저나 외부 의존성이 없는가
+- [ ] `eventListener`가 `Event enum`을 받는 closure 형태로 정의되었는가
+- [ ] 이벤트가 `Event` enum 기반으로 타입 안전하게 정의되었는가
+- [ ] `<Name>Component.swift`, `<Name>Component+Configuration.swift`, `<Name>Component+Event.swift`가 분리되어 있는가
+- [ ] 계산 로직이 복잡한 경우 `<Name>Component+Calculate.swift`로 분리했는가
+- [ ] 하위 뷰가 `Components/` 디렉토리로 분리되어 있는가
+
+## 참고
+
+- 디자인 토큰, Tier 분류 기준은 `.agents/rules/design-guide.md`를 따릅니다.

--- a/.agents/skills/hook-check-rules/SKILL.md
+++ b/.agents/skills/hook-check-rules/SKILL.md
@@ -15,6 +15,7 @@ Claude `UserPromptSubmit` 훅(`check-rules.sh`)의 동작을 Codex 스킬로 포
 - PR/pull request/풀리퀘스트
 - 브랜치/branch
 - 아키텍처/architecture/모듈/module
+- 디자인시스템/design system/designsystem
 - 리뷰/review/code review/코드 리뷰
 
 ## 실행 단계
@@ -27,6 +28,7 @@ Claude `UserPromptSubmit` 훅(`check-rules.sh`)의 동작을 Codex 스킬로 포
 - `(pr|pull request|풀리퀘스트|풀 리퀘스트)` -> `.agents/rules/pr-convention.md`
 - `(브랜치|branch)` -> `.agents/rules/branch-convention.md`
 - `(아키텍처|architecture|모듈|module)` -> `.agents/rules/Architecture.md`
+- `(디자인시스템|디자인 시스템|design system|designsystem)` -> `.agents/rules/design-system-component-convention.md`
 - `(리뷰|review|code review|코드 리뷰)` -> `.agents/rules/code-review-convention.md`
 
 ### 2. 관련 규칙 문서 로드

--- a/.claude/hooks/check-rules.sh
+++ b/.claude/hooks/check-rules.sh
@@ -44,6 +44,13 @@ if echo "$input_lower" | grep -qE "(아키텍처|architecture|모듈|module)"; t
     fi
 fi
 
+# 디자인시스템 관련 키워드 감지
+if echo "$input_lower" | grep -qE "(디자인시스템|디자인 시스템|design system|designsystem)"; then
+    if [ -f "$rules_dir/design-system-component-convention.md" ]; then
+        injected_rules="$injected_rules\n\n---\n📋 관련 규칙: 디자인시스템 컴포넌트 컨벤션\n\n$(cat "$rules_dir/design-system-component-convention.md")"
+    fi
+fi
+
 # 코드 리뷰 관련 키워드 감지
 if echo "$input_lower" | grep -qE "(리뷰|review|code review|코드 리뷰|코드리뷰)"; then
     if [ -f "$rules_dir/code-review-convention.md" ]; then


### PR DESCRIPTION
## 주요 작업 내용
### 디자인시스템 컴포넌트 생성 규칙 문서 추가
- `Configuration` 필수, `eventListener` 옵셔널 생성자 규칙을 문서화했습니다.
- `Event enum + closure typealias` 기반 이벤트 전달 방식을 정리했습니다.
- `TierN/<Name>Component/` 디렉토리와 `+Configuration`, `+Event`, `+Calculate`, `Components/` 파일 구조 규칙을 추가했습니다.

### 규칙 탐색 및 자동 주입 경로 반영
- `.agents/INDEX.md` 컨벤션 섹션에 새 규칙 문서를 등록했습니다.
- `hook-check-rules` 스킬과 `.claude/hooks/check-rules.sh`에 디자인시스템 키워드 매핑을 추가했습니다.

## 참고사항
- 변경 범위는 문서와 규칙 자동 주입 훅에 한정됩니다.
- `bash -n .claude/hooks/check-rules.sh`, `git diff --check`로 기본 검증을 수행했습니다.

## 스크린샷
- 없음
