### PR TITLE
(#67) extraBold 폰트 굵기 미반영 문제를 수정합니다.

### DIFF
--- a/SeukCalendar/DesignSystem/DesignSystem/ResourceSystem/FontSystem/Common/TextStyleType.swift
+++ b/SeukCalendar/DesignSystem/DesignSystem/ResourceSystem/FontSystem/Common/TextStyleType.swift
@@ -19,8 +19,12 @@ public protocol FontStyleType {
 }
 
 public extension FontStyleType {
+  var fontName: String {
+    "\(Family.name)-\(weight.rawValue)"
+  }
+
   var uiFont: PlatformFont {
-    return PlatformFont(name: "\(Family.name)-\(weight)", size: size) ?? PlatformFont.systemFont(ofSize: size)
+    return PlatformFont(name: fontName, size: size) ?? PlatformFont.systemFont(ofSize: size)
   }
 
   var lineHeightRatio: CGFloat {

--- a/SeukCalendar/DesignSystem/DesignSystemTests/DesignSystemTests.swift
+++ b/SeukCalendar/DesignSystem/DesignSystemTests/DesignSystemTests.swift
@@ -3,6 +3,14 @@ import Foundation
 import Testing
 
 struct DesignSystemTests {
+  @Test("WidgetXLargeFont_ExtraBold_폰트이름을_정확히_해석합니다")
+  func widgetXLargeFontResolvesExtraBoldFontName() {
+    FontManager.shared.register()
+
+    #expect(Widget.Large.xLarge.fontName == "Pretendard-ExtraBold")
+    #expect(Widget.Large.xLarge.uiFont.fontName == "Pretendard-ExtraBold")
+  }
+
   @Test("makeConfiguration_월간_그리드와_선택일_상태를_생성합니다")
   func makeConfigurationBuildsMonthGridAndSelectionState() {
     let configuration = HomeCalendarConfigurationBuilder.makeConfiguration(

--- a/SeukCalendar/DesignSystem/DesignSystemTests/DesignSystemTests.swift
+++ b/SeukCalendar/DesignSystem/DesignSystemTests/DesignSystemTests.swift
@@ -3,12 +3,15 @@ import Foundation
 import Testing
 
 struct DesignSystemTests {
-  @Test("WidgetXLargeFont_ExtraBold_폰트이름을_정확히_해석합니다")
-  func widgetXLargeFontResolvesExtraBoldFontName() {
+  @Test("DesignSystem_번들에_포함된_모든_폰트가_등록됩니다")
+  func registersAllBundledFonts() {
     FontManager.shared.register()
 
-    #expect(Widget.Large.xLarge.fontName == "Pretendard-ExtraBold")
-    #expect(Widget.Large.xLarge.uiFont.fontName == "Pretendard-ExtraBold")
+    let bundledFontNames = Self.bundledFontNames
+    let unresolvedFontNames = bundledFontNames.filter { PlatformFont(name: $0, size: 12) == nil }
+
+    #expect(bundledFontNames.isEmpty == false)
+    #expect(unresolvedFontNames.isEmpty)
   }
 
   @Test("makeConfiguration_월간_그리드와_선택일_상태를_생성합니다")
@@ -79,6 +82,30 @@ struct DesignSystemTests {
 }
 
 private extension DesignSystemTests {
+  static var bundledFontNames: [String] {
+    guard let fontsRootURL = Bundle.designSystemBundle.resourceURL?
+      .appendingPathComponent("Fonts", isDirectory: true)
+    else {
+      return []
+    }
+
+    var fontURLs: [URL] = []
+    let enumerator = FileManager.default.enumerator(
+      at: fontsRootURL,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles]
+    )
+
+    while let url = enumerator?.nextObject() as? URL {
+      guard ["otf", "ttf"].contains(url.pathExtension.lowercased()) else { continue }
+      fontURLs.append(url)
+    }
+
+    return fontURLs
+      .map { $0.deletingPathExtension().lastPathComponent }
+      .sorted()
+  }
+
   static var fixedCalendar: Calendar {
     var calendar = Calendar(identifier: .gregorian)
     calendar.locale = Locale(identifier: "ko_KR")


### PR DESCRIPTION
## 주요 작업 내용

### FontStyleType 폰트 이름 해석 수정
- `FontStyleType`에 공통 `fontName`을 추가했습니다.
- 폰트 생성 시 enum 문자열 보간 대신 `weight.rawValue`를 사용하도록 변경했습니다.
- `Pretendard-extraBold`가 아닌 `Pretendard-ExtraBold`를 조회하도록 수정해 fallback을 제거했습니다.

### 회귀 테스트 추가
- `Widget.Large.xLarge`가 올바른 `fontName`과 `uiFont.fontName`을 반환하는 테스트를 추가했습니다.

## 참고사항

- 이슈: #67
- 검증: `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme DesignSystem -destination 'platform=iOS Simulator,id=ECBE0638-7244-44E1-AE29-3CF1587E1A06' build` 성공
- 검증: `xcodebuild ... test`는 기존 `WidgetComponentTests.swift`의 `SCColor.Semantic.Content.contentPrimary/contentSecondary` 멤버 미존재 컴파일 오류로 실패했습니다. 이번 변경과는 무관한 기존 테스트 이슈입니다.

## 스크린샷

- 없음
