### PR TITLE
(#69) 위젯 컴포넌트 테스트 실패 문제를 수정합니다.

### DIFF
--- a/SeukCalendar/DesignSystem/DesignSystemTests/WidgetComponentTests.swift
+++ b/SeukCalendar/DesignSystem/DesignSystemTests/WidgetComponentTests.swift
@@ -22,7 +22,7 @@ struct WidgetComponentTests {
     let configuration = WidgetDayCellComponent.Configuration(
       date: Self.sampleDate,
       isToday: false,
-      dayTextColor: .semantic.Content.contentPrimary,
+      dayTextColor: .semantic.Content.primary,
       segments: [
         Self.segment(label: "첫 일정"),
         Self.segment(label: "둘 일정"),
@@ -44,7 +44,7 @@ struct WidgetComponentTests {
         WidgetDayCellComponent.Configuration(
           date: Self.calendar.date(byAdding: .day, value: index, to: Self.sampleDate) ?? Self.sampleDate,
           isToday: false,
-          dayTextColor: .semantic.Content.contentSecondary
+          dayTextColor: .semantic.Content.secondary
         )
       }
     )
@@ -62,7 +62,7 @@ struct WidgetComponentTests {
           WidgetDayCellComponent.Configuration(
             date: Self.calendar.date(byAdding: .day, value: (weekIndex * 7) + dayIndex, to: baseDate) ?? baseDate,
             isToday: false,
-            dayTextColor: .semantic.Content.contentSecondary
+            dayTextColor: .semantic.Content.secondary
           )
         }
       }


### PR DESCRIPTION
## 주요 작업 내용

### WidgetComponentTests 색상 토큰 정정
- `WidgetComponentTests.swift`가 더 이상 존재하지 않는 `contentPrimary`, `contentSecondary`를 참조하던 부분을 현재 DesignSystem 토큰명인 `primary`, `secondary`로 교체했습니다.
- 위젯 컴포넌트 테스트가 실제 컴포넌트 프리뷰/구성 코드와 동일한 semantic color를 사용하도록 맞췄습니다.

## 참고사항

- 이슈: #69
- 검증: `xcodebuild -workspace SeukCalendar/SeukCalendar.xcworkspace -scheme DesignSystem -destination 'platform=iOS Simulator,id=ECBE0638-7244-44E1-AE29-3CF1587E1A06' test` 통과

## 스크린샷

- 없음
